### PR TITLE
lib: allow specification of dotted path elements in collate and drop

### DIFF
--- a/testdata/collate_a_b.b.txt
+++ b/testdata/collate_a_b.b.txt
@@ -8,13 +8,16 @@ cmp stdout want.txt
 		{"b": 1},
 		{"b": 2},
 		{"b": 3}
-    ],
+	],
     "b": [
 		{"b": -1, "c": 10},
 		{"b": -2, "c": 20},
 		{"b": -3, "c": 30}
-    ]
-}.collate(["a","b.b"])
+	],
+    "c.d": [
+		{"e": "dotted path element", "f": 10},
+	]
+}.collate(["a","b.b","c\\.d.e"])
 -- want.txt --
 [
 	{
@@ -28,5 +31,6 @@ cmp stdout want.txt
 	},
 	-1,
 	-2,
-	-3
+	-3,
+	"dotted path element"
 ]

--- a/testdata/drop_a_b.b.txt
+++ b/testdata/drop_a_b.b.txt
@@ -8,13 +8,18 @@ cmp stdout want.txt
 		{"b": 1},
 		{"b": 2},
 		{"b": 3}
-    ],
-    "b": [
+	],
+	"b": [
 		{"b": -1, "c": 10},
 		{"b": -2, "c": 20},
 		{"b": -3, "c": 30}
-    ]
-}.drop(["a","b.b"])
+	],
+	"b.b": "don't drop",
+	"drop.this": {
+		"path": true,
+		"keep": true
+	}
+}.drop(["a","b.b","drop\\.this.path"])
 -- want.txt --
 {
 	"b": [
@@ -27,5 +32,9 @@ cmp stdout want.txt
 		{
 			"c": 30
 		}
-	]
+	],
+	"b.b": "don't drop",
+	"drop.this": {
+		"keep": true
+	}
 }


### PR DESCRIPTION
This adds the ability to perform collate and drop operations on path elements that contain the dot path separator.

Please take a look.