### PR TITLE
lib: add Basic Authentication to HTTP extension

### DIFF
--- a/mito.go
+++ b/mito.go
@@ -148,7 +148,7 @@ var (
 		"try":         lib.Try(),
 		"file":        lib.File(mimetypes),
 		"mime":        lib.MIME(mimetypes),
-		"http":        lib.HTTP(nil, nil),
+		"http":        lib.HTTP(nil, nil, nil),
 		"limit":       lib.Limit(limitPolicies),
 	}
 

--- a/testdata/basic_auth.txt
+++ b/testdata/basic_auth.txt
@@ -1,0 +1,22 @@
+mito -use http src.cel
+! stderr .
+cmp stdout want.txt
+
+-- src.cel --
+request("GET", "http://www.example.com/").basic_authentication("username", "password")
+-- want.txt --
+{
+	"Close": false,
+	"ContentLength": 0,
+	"Header": {
+		"Authorization": [
+			"Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+		]
+	},
+	"Host": "www.example.com",
+	"Method": "GET",
+	"Proto": "HTTP/1.1",
+	"ProtoMajor": 1,
+	"ProtoMinor": 1,
+	"URL": "http://www.example.com/"
+}

--- a/testdata/request.txt
+++ b/testdata/request.txt
@@ -7,7 +7,7 @@ cmp stdout want.txt
 	request("GET", "http://www.example.com/"),
 	request("GET", "http://www.example.com/", "request data"),
 	request("GET", "http://www.example.com/").with({"Header":{
-		"Authorization": "Basic "+string(base64("username:password")),
+		"Authorization": ["Basic "+string(base64("username:password"))],
 	}}),
 	get_request("http://www.example.com/"),
 	post_request("http://www.example.com/", "text/plain", "request data"),
@@ -41,7 +41,9 @@ cmp stdout want.txt
 		"Close": false,
 		"ContentLength": 0,
 		"Header": {
-			"Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+			"Authorization": [
+				"Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+			]
 		},
 		"Host": "www.example.com",
 		"Method": "GET",


### PR DESCRIPTION
Previously, the only way to enable Basic Authentication was to manually construct a request object, adding the Authorization header appropriately and then using do_request. This change allows users to specify a Basic Authentication user/pass for all request using the head, get and post functions. Requests returned by request, get_request and post_request are not affected by the state of the Basic Authentication parameter as they can be easily altered using the wither pattern shown in the request documentation example.

No validation of the state of the auth parameter is made and this is the responsibility of the caller of `lib.HTTP`/`lib.HTTPWithContext`.

For elastic/beats#34609