### PR TITLE
lib/xml: make parser strict for xml documents

### DIFF
--- a/lib/xml/xml_test.go
+++ b/lib/xml/xml_test.go
@@ -496,7 +496,7 @@ var decodeXMLTests = []struct {
 			},
 		},
 	},
-	2: { // Incomplete XML: no proc-inst.
+	2: { // Incomplete XML: no proc-inst; allowed.
 		doc: `
 <order orderid="56733" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="sales.xsd">
   <sender>Ástríðr Ragnar</sender>
@@ -588,7 +588,6 @@ var decodeXMLTests = []struct {
 				"xsi":                       "http://www.w3.org/2001/XMLSchema-instance",
 			},
 		},
-		wantErr: io.ErrUnexpectedEOF,
 	},
 	3: { // Incomplete XML: no root element.
 		doc: `

--- a/testdata/xml.txt
+++ b/testdata/xml.txt
@@ -14,7 +14,11 @@ xsd:
 	"multi_element": file('order_two.xml').as(f, {
 		"with_xsd": f.decode_xml("order"),
 		"without_xsd": f.decode_xml(),
-	})
+	}),
+	"invalid_xml": file('order.json').as(f, {
+		"with_xsd": try(f.decode_xml("order")),
+		"without_xsd": try(f.decode_xml()),
+	}),
 }
 -- order.xsd --
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -94,8 +98,37 @@ xsd:
     <sent>TRUE</sent>
   </item>
 </order>
+-- order.json --
+{
+	"order": {
+		"address": {
+			"address": "Beekplantsoen 594, 2 hoog, 6849 IG",
+			"city": "Boekend",
+			"company": "Sydøstlige Gruppe",
+			"country": "Netherlands",
+			"name": "Joord Lennart"
+		},
+		"item": [
+			{
+				"cost": 99.95,
+				"name": "Egil's Saga",
+				"note": "Free Sample",
+				"number": 1,
+				"sent": false
+			}
+		],
+		"noNamespaceSchemaLocation": "sales.xsd",
+		"orderid": "56733",
+		"sender": "Ástríðr Ragnar",
+		"xsi": "http://www.w3.org/2001/XMLSchema-instance"
+	}
+}
 -- want.txt --
 {
+	"invalid_xml": {
+		"with_xsd": "failed to unmarshal XML document: unexpected EOF",
+		"without_xsd": "failed to unmarshal XML document: unexpected EOF"
+	},
 	"multi_element": {
 		"with_xsd": {
 			"doc": {


### PR DESCRIPTION
Require that XML documents have an XML declaration and at least one start element. Element pairing is handled by the stdlib xml decoder.

Please take a look.