### PR TITLE
lib: add support for md5 hashing

### DIFF
--- a/testdata/md5.txt
+++ b/testdata/md5.txt
@@ -1,0 +1,26 @@
+mito -use crypto src.cel
+! stderr .
+cmp stdout want.txt
+
+-- src.cel --
+[
+	b"hello world".md5(),
+	b"hello world".md5().hex(),
+	md5(b"hello world"),
+	md5(b"hello world").hex(),
+	"hello world".md5(),
+	"hello world".md5().hex(),
+	md5("hello world"),
+	md5("hello world").hex(),
+]
+-- want.txt --
+[
+	"XrY7u+Ae7tCTyyK7j1rNww==",
+	"5eb63bbbe01eeed093cb22bb8f5acdc3",
+	"XrY7u+Ae7tCTyyK7j1rNww==",
+	"5eb63bbbe01eeed093cb22bb8f5acdc3",
+	"XrY7u+Ae7tCTyyK7j1rNww==",
+	"5eb63bbbe01eeed093cb22bb8f5acdc3",
+	"XrY7u+Ae7tCTyyK7j1rNww==",
+	"5eb63bbbe01eeed093cb22bb8f5acdc3"
+]


### PR DESCRIPTION
This adds MD5 hash support. At a pinch, this can be used by users to implement digest auth within CEL code. A full digest auth helper will come in a later change.

Please take a look.

For elastic/beats#35514