### PR TITLE
lib: relax error expectation for tls certificate failure

### DIFF
--- a/testdata/serve_tls.txt
+++ b/testdata/serve_tls.txt
@@ -4,7 +4,7 @@ cmpenv src.cel src_var.cel
 
 ! mito -use http src.cel
 ! stdout .
-stderr 'failed eval: Get "https://127.0.0.1:[0-9]{1,5}": (?:tls: failed to verify certificate: )?x509: certificate signed by unknown authority'
+stderr 'failed eval: Get "https://127.0.0.1:[0-9]{1,5}": (?:tls: failed to verify certificate: )?x509: (?:certificate signed by unknown authority|.*certificate is not trusted)'
 
 mito -use http -insecure src.cel
 cmp stdout want_insecure.txt


### PR DESCRIPTION
On darwin after go1.21, self signed certificates may result in an error in the form of "x509: “valid.testing.golang.invalid” certificate is not trusted". So add this to the pattern for server_tls failure.

Please take a look.