### PR TITLE
mito: add benchmarks

### DIFF
--- a/mito.go
+++ b/mito.go
@@ -279,23 +279,18 @@ func run(prg cel.Program, fast bool, input interface{}) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed proto conversion: %v", err)
 	}
-	b, err := protojson.MarshalOptions{}.Marshal(v.(proto.Message))
-	if err != nil {
-		return "", fmt.Errorf("failed native conversion: %v", err)
-	}
 	if fast {
+		b, err := protojson.MarshalOptions{}.Marshal(v.(proto.Message))
+		if err != nil {
+			return "", fmt.Errorf("failed native conversion: %v", err)
+		}
 		return string(b), nil
-	}
-	var res interface{}
-	err = json.Unmarshal(b, &res)
-	if err != nil {
-		return "", fmt.Errorf("failed json conversion: %v", err)
 	}
 	var buf strings.Builder
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "\t")
-	err = enc.Encode(res)
+	err = enc.Encode(v.(*structpb.Value).AsInterface())
 	return strings.TrimRight(buf.String(), "\n"), err
 }
 

--- a/mito_bench_test.go
+++ b/mito_bench_test.go
@@ -1,0 +1,332 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mito
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elastic/mito/lib"
+	"github.com/google/cel-go/cel"
+)
+
+var (
+	fastMarshal = flag.Bool("fast_marshal", false, "specify fast/non-pretty marshaling of the result")
+	sampleBench = flag.Bool("sample_bench", false, "log one benchmark result for each benchmark")
+)
+
+var benchmarks = []struct {
+	name  string
+	setup func(*testing.B) (prg cel.Program, state any, err error)
+}{
+	// Self-contained.
+	{
+		name: "hello_world_static",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			prg, err := compile(
+				`"hello world"`,
+				root,
+			)
+			return prg, nil, err
+		},
+	},
+	{
+		name: "hello_world_object_static",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			prg, err := compile(
+				`{"greeting":"hello world"}`,
+				root,
+			)
+			return prg, nil, err
+		},
+	},
+	{
+		name: "nested_static",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			prg, err := compile(
+				`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`,
+				root,
+			)
+			return prg, nil, err
+		},
+	},
+	{
+		name: "encode_json_static",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			prg, err := compile(
+				`{"a":{"b":{"c":{"d":{"e":"f"}}}}}.encode_json()`,
+				root,
+				lib.JSON(nil),
+			)
+			return prg, nil, err
+		},
+	},
+	{
+		name: "nested_collate_static",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			prg, err := compile(
+				`{"a":{"b":{"c":{"d":{"e":"f"}}}}}.collate("a.b.c.d.e")`,
+				root,
+				lib.Collections(),
+			)
+			return prg, nil, err
+		},
+	},
+
+	// From state.
+	{
+		name: "hello_world_state",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			prg, err := compile(root, root)
+			state := map[string]any{root: "hello world"}
+			return prg, state, err
+		},
+	},
+	{
+		name: "hello_world_object_state",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			prg, err := compile(
+				`{"greeting":state.greeting}`,
+				root,
+			)
+			state := map[string]any{root: mustParseJSON(`{"greeting": "hello world}"}`)}
+			return prg, state, err
+		},
+	},
+	{
+		name: "nested_state",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			prg, err := compile(root, root)
+			state := map[string]any{root: mustParseJSON(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`)}
+			return prg, state, err
+		},
+	},
+	{
+		name: "encode_json_state",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			prg, err := compile(`state.encode_json()`,
+				root,
+				lib.JSON(nil),
+			)
+			state := map[string]any{root: mustParseJSON(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`)}
+			return prg, state, err
+		},
+	},
+	// These two have additional complexity due to a wart that requires
+	// that we elevate the value to get the environment to know that state
+	// is a map.
+	//
+	// There should be an easier way to do this. It has come up in DX discussions.
+	//
+	// Similar in the net versions below.
+	{
+		name: "nested_collate_list_state",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			prg, err := compile(`[state].collate("a.b.c.d.e")`,
+				root,
+				lib.Collections(),
+			)
+			state := map[string]any{root: mustParseJSON(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`)}
+			return prg, state, err
+		},
+	},
+	{
+		name: "nested_collate_map_state",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			prg, err := compile(`{"state": state}.collate("state.a.b.c.d.e")`,
+				root,
+				lib.Collections(),
+			)
+			state := map[string]any{root: mustParseJSON(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`)}
+			return prg, state, err
+		},
+	},
+
+	// From net.
+	{
+		// null_net just does a GET and uses the result in the cheapest way.
+		// This is to get an idea of how much of the bench work is coming from
+		// the test server.
+		name: "null_net",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			b.Cleanup(func() { srv.Close() })
+			prg, err := compile(
+				fmt.Sprintf(`get(%q).size()`, srv.URL),
+				root,
+				lib.HTTP(srv.Client(), nil, nil),
+			)
+			return prg, nil, err
+		},
+	},
+	{
+		name: "hello_world_net",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte("hello world"))
+			}))
+			b.Cleanup(func() { srv.Close() })
+			prg, err := compile(
+				fmt.Sprintf(`string(get(%q).Body)`, srv.URL),
+				root,
+				lib.HTTP(srv.Client(), nil, nil),
+			)
+			return prg, nil, err
+		},
+	},
+	{
+		name: "hello_world_object_net",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte(`{"greeting":"hello world"}`))
+			}))
+			b.Cleanup(func() { srv.Close() })
+			prg, err := compile(
+				fmt.Sprintf(`{"greeting":bytes(get(%q).Body).decode_json().greeting}`, srv.URL),
+				root,
+				lib.HTTP(srv.Client(), nil, nil),
+				lib.JSON(nil),
+			)
+			return prg, nil, err
+		},
+	},
+	{
+		name: "nested_net",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`))
+			}))
+			b.Cleanup(func() { srv.Close() })
+			prg, err := compile(
+				fmt.Sprintf(`bytes(get(%q).Body).decode_json()`, srv.URL),
+				root,
+				lib.HTTP(srv.Client(), nil, nil),
+				lib.JSON(nil),
+			)
+			return prg, nil, err
+		},
+	},
+	{
+		name: "encode_json_null_net",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`))
+			}))
+			b.Cleanup(func() { srv.Close() })
+			prg, err := compile(
+				fmt.Sprintf(`get(%q).Body`, srv.URL),
+				root,
+				lib.HTTP(srv.Client(), nil, nil),
+				lib.JSON(nil),
+			)
+			return prg, nil, err
+		},
+	},
+	{
+		// encode_json_net should bead assessed with reference to encode_json_null_net
+		// which performs the same request but does not round-trip the object.
+		name: "encode_json_net",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`))
+			}))
+			b.Cleanup(func() { srv.Close() })
+			prg, err := compile(
+				fmt.Sprintf(`bytes(get(%q).Body).decode_json().encode_json()`, srv.URL),
+				root,
+				lib.HTTP(srv.Client(), nil, nil),
+				lib.JSON(nil),
+			)
+			return prg, nil, err
+		},
+	},
+	{
+		name: "nested_collate_list_net",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`))
+			}))
+			b.Cleanup(func() { srv.Close() })
+			prg, err := compile(
+				fmt.Sprintf(`[bytes(get(%q).Body).decode_json()].collate("a.b.c.d.e")`, srv.URL),
+				root,
+				lib.HTTP(srv.Client(), nil, nil),
+				lib.JSON(nil),
+				lib.Collections(),
+			)
+			return prg, nil, err
+		},
+	},
+	{
+		name: "nested_collate_map_net",
+		setup: func(b *testing.B) (cel.Program, any, error) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`))
+			}))
+			b.Cleanup(func() { srv.Close() })
+			prg, err := compile(
+				fmt.Sprintf(`{"body": bytes(get(%q).Body).decode_json()}.collate("body.a.b.c.d.e")`, srv.URL),
+				root,
+				lib.HTTP(srv.Client(), nil, nil),
+				lib.JSON(nil),
+				lib.Collections(),
+			)
+			return prg, nil, err
+		},
+	},
+}
+
+func BenchmarkMito(b *testing.B) {
+	for _, bench := range benchmarks {
+		sampled := false
+		b.Run(bench.name, func(b *testing.B) {
+			b.StopTimer()
+			prg, state, err := bench.setup(b)
+			if err != nil {
+				b.Fatalf("failed setup: %v", err)
+			}
+			b.StartTimer()
+
+			for i := 0; i < b.N; i++ {
+				v, err := run(prg, *fastMarshal, state)
+				if err != nil {
+					b.Fatalf("failed operation: %v", err)
+				}
+				if *sampleBench && !sampled {
+					sampled = true
+					b.Logf("\n%s", v)
+				}
+			}
+		})
+	}
+}
+
+func mustParseJSON(s string) any {
+	var v any
+	err := json.Unmarshal([]byte(s), &v)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}


### PR DESCRIPTION
This adds benchmarks for static, state parameter and network obtained data processing. In general, there is little low-hanging fruit except for the final JSON format clean-up done by eval, demonstrated by the benchmark comparisons below. This code is not run in filebeat, but does hint at optimisations that could be done there.

```
$ go test -run ^$ -bench . -count 10 > bench_not_fast.out
$ go test -run ^$ -bench . -count 10 -fast_marshal > bench_fast.out
$ benchstat bench_not_fast.out bench_fast.out
goos: darwin
goarch: amd64
pkg: github.com/elastic/mito
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
                                  │ bench_not_fast.out │           bench_fast.out            │
                                  │       sec/op       │   sec/op     vs base                │
Mito/hello_world_static-16                1466.5n ± 3%   651.6n ± 5%  -55.57% (p=0.000 n=10)
Mito/hello_world_object_static-16          5.408µ ± 4%   3.163µ ± 3%  -41.51% (p=0.000 n=10)
Mito/nested_static-16                      17.88µ ± 5%   12.22µ ± 2%  -31.67% (p=0.000 n=10)
Mito/encode_json_static-16                 22.43µ ± 2%   21.30µ ± 4%   -5.06% (p=0.002 n=10)
Mito/nested_collate_static-16              5.465µ ± 3%   4.405µ ± 3%  -19.39% (p=0.000 n=10)
Mito/hello_world_state-16                 1559.5n ± 3%   751.9n ± 2%  -51.79% (p=0.000 n=10)
Mito/hello_world_object_state-16           5.821µ ± 4%   3.355µ ± 2%  -42.37% (p=0.000 n=10)
Mito/nested_state-16                       16.30µ ± 3%   10.85µ ± 1%  -33.45% (p=0.000 n=10)
Mito/encode_json_state-16                  4.898µ ± 3%   3.501µ ± 2%  -28.53% (p=0.000 n=10)
Mito/nested_collate_list_state-16          14.61µ ± 3%   13.37µ ± 7%   -8.54% (p=0.002 n=10)
Mito/nested_collate_map_state-16           14.76µ ± 3%   13.49µ ± 3%   -8.59% (p=0.000 n=10)
Mito/null_net-16                           78.49µ ± 8%   72.04µ ± 3%   -8.22% (p=0.000 n=10)
Mito/hello_world_net-16                    82.69µ ± 3%   81.37µ ± 3%        ~ (p=0.315 n=10)
Mito/hello_world_object_net-16             95.39µ ± 1%   92.60µ ± 4%   -2.92% (p=0.007 n=10)
Mito/nested_net-16                         111.0µ ± 3%   102.7µ ± 2%   -7.45% (p=0.000 n=10)
Mito/encode_json_null_net-16               86.98µ ± 7%   79.97µ ± 3%   -8.06% (p=0.001 n=10)
Mito/encode_json_net-16                    94.39µ ± 4%   91.97µ ± 4%        ~ (p=0.280 n=10)
Mito/nested_collate_list_net-16            107.0µ ± 3%   106.8µ ± 5%        ~ (p=1.000 n=10)
Mito/nested_collate_map_net-16             107.4µ ± 3%   107.0µ ± 6%        ~ (p=1.000 n=10)
geomean                                    21.32µ        16.80µ       -21.19%
```

Applying the obvious optimisation (second commit here which is applicable in filebeat) gives a performance improvement equivalent to (better than) the fast path in table above.
```
$ go test -run ^$ -bench . -count 10 > bench_not_fast_new.out
$ benchstat bench_not_fast.out bench_not_fast_new.out
goos: darwin
goarch: amd64
pkg: github.com/elastic/mito
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
                                  │ bench_not_fast.out │       bench_not_fast_new.out        │
                                  │       sec/op       │   sec/op     vs base                │
Mito/hello_world_static-16                1466.5n ± 3%   607.8n ± 2%  -58.55% (p=0.000 n=10)
Mito/hello_world_object_static-16          5.408µ ± 4%   2.766µ ± 3%  -48.85% (p=0.000 n=10)
Mito/nested_static-16                      17.88µ ± 5%   10.64µ ± 8%  -40.50% (p=0.000 n=10)
Mito/encode_json_static-16                 22.43µ ± 2%   21.94µ ± 2%   -2.22% (p=0.029 n=10)
Mito/nested_collate_static-16              5.465µ ± 3%   3.848µ ± 2%  -29.59% (p=0.000 n=10)
Mito/hello_world_state-16                 1559.5n ± 3%   693.2n ± 4%  -55.55% (p=0.000 n=10)
Mito/hello_world_object_state-16           5.821µ ± 4%   2.887µ ± 3%  -50.41% (p=0.000 n=10)
Mito/nested_state-16                      16.302µ ± 3%   9.061µ ± 2%  -44.42% (p=0.000 n=10)
Mito/encode_json_state-16                  4.898µ ± 3%   3.387µ ± 3%  -30.86% (p=0.000 n=10)
Mito/nested_collate_list_state-16          14.61µ ± 3%   12.15µ ± 4%  -16.87% (p=0.000 n=10)
Mito/nested_collate_map_state-16           14.76µ ± 3%   12.44µ ± 4%  -15.71% (p=0.000 n=10)
Mito/null_net-16                           78.49µ ± 8%   72.25µ ± 4%   -7.94% (p=0.000 n=10)
Mito/hello_world_net-16                    82.69µ ± 3%   79.93µ ± 4%   -3.33% (p=0.000 n=10)
Mito/hello_world_object_net-16             95.39µ ± 1%   89.20µ ± 3%   -6.49% (p=0.000 n=10)
Mito/nested_net-16                         111.0µ ± 3%   100.2µ ± 4%   -9.77% (p=0.000 n=10)
Mito/encode_json_null_net-16               86.98µ ± 7%   80.82µ ± 4%   -7.08% (p=0.004 n=10)
Mito/encode_json_net-16                    94.39µ ± 4%   88.58µ ± 3%   -6.16% (p=0.002 n=10)
Mito/nested_collate_list_net-16            107.0µ ± 3%   102.6µ ± 2%   -4.09% (p=0.001 n=10)
Mito/nested_collate_map_net-16             107.4µ ± 3%   102.7µ ± 2%   -4.39% (p=0.001 n=10)
geomean                                    21.32µ        15.73µ       -26.22%
```

Please take a look.