### PR TITLE
lib: avoid type conversions in encode_json if possible

### DIFF
--- a/lib/json.go
+++ b/lib/json.go
@@ -20,10 +20,7 @@ package lib
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
-	"reflect"
 
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/cel"
@@ -32,8 +29,6 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter/functions"
 	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
 // JSON returns a cel.EnvOption to configure extended functions for JSON
@@ -193,59 +188,15 @@ func (l jsonLib) ProgramOptions() []cel.ProgramOption {
 }
 
 func encodeJSON(val ref.Val) ref.Val {
-	var (
-		v   interface{}
-		err error
-	)
-	typ, ok := encodableTypes[val.Type()]
-	if ok {
-		v, err = val.ConvertToNative(typ)
-		if err != nil {
-			// This should never happen.
-			panic(fmt.Sprintf("json encode mapping out of sync: %v", err))
-		}
-	} else {
-		for _, typ := range protobufTypes {
-			v, err = val.ConvertToNative(typ)
-			if err != nil {
-				v = nil
-			} else {
-				break
-			}
-		}
+	v, err := val.ConvertToNative(structpbValueType)
+	if err != nil {
+		return types.NewErr("failed proto conversion: %v", err)
 	}
-	if v == nil {
-		return types.NewErr("failed to get native value for JSON")
-	}
-	b, err := json.Marshal(v)
-	errType := &json.UnsupportedTypeError{}
-	switch {
-	case err == nil:
-		return types.String(b)
-	case errors.As(err, &errType):
-		// We could not marshal over ref.Val most likely, so convert
-		// to protobuf as an intermediate and retry.
-		v, err := val.ConvertToNative(reflect.TypeOf(&structpb.Value{}))
-		if err != nil {
-			return types.NewErr("failed proto conversion: %v", err)
-		}
-		b, err := protojson.MarshalOptions{}.Marshal(v.(proto.Message))
-		if err != nil {
-			return types.NewErr("failed native conversion: %v", err)
-		}
-		var res interface{}
-		err = json.Unmarshal(b, &res)
-		if err != nil {
-			return types.NewErr("failed json conversion: %v", err)
-		}
-		b, err = json.Marshal(res)
-		if err != nil {
-			return types.NewErr("failed to marshal value to JSON: %v", err)
-		}
-		return types.String(b)
-	default:
+	b, err := json.Marshal(v.(*structpb.Value).AsInterface())
+	if err != nil {
 		return types.NewErr("failed to marshal value to JSON: %v", err)
 	}
+	return types.String(b)
 }
 
 func (l jsonLib) decodeJSON(val ref.Val) ref.Val {

--- a/lib/types.go
+++ b/lib/types.go
@@ -60,7 +60,7 @@ var (
 
 	// Linear search for proto.Message mappings and others.
 	protobufTypes = []reflect.Type{
-		reflect.TypeOf((*structpb.Value)(nil)),
+		structpbValueType,
 		reflect.TypeOf((*structpb.ListValue)(nil)),
 		reflect.TypeOf((*structpb.Struct)(nil)),
 		// Catch all.
@@ -78,4 +78,6 @@ var (
 	reflectMapStringStringSliceType = reflect.TypeOf(map[string][]string(nil))
 	reflectStringType               = reflect.TypeOf("")
 	reflectStringSliceType          = reflect.TypeOf([]string(nil))
+
+	structpbValueType = reflect.TypeOf((*structpb.Value)(nil))
 )

--- a/testdata/json_encode.txt
+++ b/testdata/json_encode.txt
@@ -20,11 +20,15 @@ cmp stdout want.txt
 			}
 		}
 	}),
+	"plain text".encode_json(),
+	encode_json("plain text"),
 ]
 -- want.txt --
 [
 	"{\"a\":1,\"b\":[1,2,3]}",
 	"{\"a\":1,\"b\":[1,2,3]}",
 	"{\"a\":{\"b\":{\"c\":1}}}",
-	"{\"a\":{\"b\":{\"c\":1}}}"
+	"{\"a\":{\"b\":{\"c\":1}}}",
+	"\"plain text\"",
+	"\"plain text\""
 ]


### PR DESCRIPTION
This takes learning from #36 to simplify and improve the `encode_json` extension.

Depends #36 (want benchmark before merging).

Please take a look.