### PR TITLE
lib: add a list zip function to Collections

### DIFF
--- a/lib/types.go
+++ b/lib/types.go
@@ -35,6 +35,7 @@ var (
 	mapKV        = decls.NewMapType(typeK, typeV)
 	mapStringDyn = decls.NewMapType(decls.String, decls.Dyn)
 	listV        = decls.NewListType(typeV)
+	listK        = decls.NewListType(typeK)
 	listString   = decls.NewListType(decls.String)
 )
 

--- a/testdata/zip.txt
+++ b/testdata/zip.txt
@@ -1,0 +1,24 @@
+mito -use collections,try src.cel
+! stderr .
+cmp stdout want.txt
+
+-- src.cel --
+{
+	"good_instance": ["a", "b"].zip([1, 2]),
+	"good_function": zip(["a", "b"], [1, 2]),
+	"bad_instance": try(["a", "b"].zip([1, 2, 3])),
+	"bad_function": try(zip(["a", "b"], [1, 2, 3])),
+}
+-- want.txt --
+{
+	"bad_function": "zip: size(keys) != size(vals): 2 != 3",
+	"bad_instance": "zip: size(keys) != size(vals): 2 != 3",
+	"good_function": {
+		"a": 1,
+		"b": 2
+	},
+	"good_instance": {
+		"a": 1,
+		"b": 2
+	}
+}


### PR DESCRIPTION
This adds a list zip function to collections. Currently this functionality is possible, but requires 4 steps of map/collate/map/collate, with obvious unwanted complexity and garbage generation.

Uses arguably/definitively requiring this feature have been identified a couple of times.

Please take a look.