### PR TITLE
mito: add limited support for want_more

### DIFF
--- a/mito_bench_test.go
+++ b/mito_bench_test.go
@@ -309,7 +309,7 @@ func BenchmarkMito(b *testing.B) {
 			b.StartTimer()
 
 			for i := 0; i < b.N; i++ {
-				v, err := run(prg, *fastMarshal, state)
+				v, _, err := run(prg, *fastMarshal, state)
 				if err != nil {
 					b.Fatalf("failed operation: %v", err)
 				}

--- a/mito_test.go
+++ b/mito_test.go
@@ -144,7 +144,7 @@ func TestSend(t *testing.T) {
 		got = <-chans["ch"]
 	}()
 
-	res, err := eval(`42.send_to("ch").close("ch")`, "", nil, send)
+	res, _, err := eval(`42.send_to("ch").close("ch")`, "", nil, send)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestVars(t *testing.T) {
 }`
 	)
 
-	got, err := eval(src, "", interpreter.EmptyActivation(), vars)
+	got, _, err := eval(src, "", interpreter.EmptyActivation(), vars)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -359,7 +359,7 @@ var regexpTests = []struct {
 func TestRegaxp(t *testing.T) {
 	for _, test := range regexpTests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := eval(test.src, "", interpreter.EmptyActivation(), lib.Regexp(test.regexps))
+			got, _, err := eval(test.src, "", interpreter.EmptyActivation(), lib.Regexp(test.regexps))
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/testdata/want_more.txt
+++ b/testdata/want_more.txt
@@ -1,0 +1,44 @@
+mito -data state.json src.cel
+! stderr .
+cmp stdout want.txt
+
+-- state.json --
+{"n": 0}
+-- src.cel --
+int(state.n).as(n, {
+	"state": {
+		"n":         n+1,
+		"want_more": n+1 < 5,
+	}
+})
+-- want.txt --
+{
+	"state": {
+		"n": 1,
+		"want_more": true
+	}
+}
+{
+	"state": {
+		"n": 2,
+		"want_more": true
+	}
+}
+{
+	"state": {
+		"n": 3,
+		"want_more": true
+	}
+}
+{
+	"state": {
+		"n": 4,
+		"want_more": true
+	}
+}
+{
+	"state": {
+		"n": 5,
+		"want_more": false
+	}
+}


### PR DESCRIPTION
When used in the Filebeat CEL input, the CEL evaluation can be repeated with the result of the current evaluation. This was originally added as a Turing escape hatch for limited use, but it has become a common idiom for expressing pagination in multistep API requests. The absence of the `want_more` option in mito means that the tool is less useful that it could be when developing CEL programs that use this idiom. So add a limited version of `want_more` support.

In the Filebeat input there are a number of checks to ensure that `want_more` will not result in runaway computation. This is necessary in that context as the program is running unattended. In the case of mito, the program is being used as a validation and debugging tool, and so will have a human watching its output. So we do not check for too many loops, or absent events (mito has no concept of events).

The only check is that there is a true `state.want_more` field in the final result.

Please take a look.