### PR TITLE
mito: simplify use of want_more

### DIFF
--- a/mito.go
+++ b/mito.go
@@ -185,19 +185,15 @@ func Main() int {
 		fmt.Println(res)
 
 		// Check if we want more. This can happen when we have a map
-		// and the map has a true boolean field, state.want_more.
-		m, ok := val.(map[string]any)
-		if !ok {
-			break
-		}
-		state, ok := m["state"].(map[string]any)
+		// and the map has a true boolean field, want_more.
+		state, ok := val.(map[string]any)
 		if !ok {
 			break
 		}
 		if more, _ := state["want_more"].(bool); !more {
 			break
 		}
-		input = val
+		input = map[string]any{"state": val}
 	}
 	return 0
 }

--- a/testdata/want_more.txt
+++ b/testdata/want_more.txt
@@ -6,39 +6,27 @@ cmp stdout want.txt
 {"n": 0}
 -- src.cel --
 int(state.n).as(n, {
-	"state": {
-		"n":         n+1,
-		"want_more": n+1 < 5,
-	}
+	"n":         n+1,
+	"want_more": n+1 < 5,
 })
 -- want.txt --
 {
-	"state": {
-		"n": 1,
-		"want_more": true
-	}
+	"n": 1,
+	"want_more": true
 }
 {
-	"state": {
-		"n": 2,
-		"want_more": true
-	}
+	"n": 2,
+	"want_more": true
 }
 {
-	"state": {
-		"n": 3,
-		"want_more": true
-	}
+	"n": 3,
+	"want_more": true
 }
 {
-	"state": {
-		"n": 4,
-		"want_more": true
-	}
+	"n": 4,
+	"want_more": true
 }
 {
-	"state": {
-		"n": 5,
-		"want_more": false
-	}
+	"n": 5,
+	"want_more": false
 }


### PR DESCRIPTION
The previous approach to want_more use creates too much friction for users since it requires that code being brought from the filebeat input be modified to wrap the final state in an object in a state field. Remove that requirement to allow simple drop-in use.

Please take a look.