### PR TITLE
lib: fix json_encode for null values

### DIFF
--- a/lib/types.go
+++ b/lib/types.go
@@ -52,7 +52,6 @@ var (
 		types.IntType:       reflectInt64Type,
 		types.ListType:      reflect.TypeOf([]interface{}(nil)),
 		types.MapType:       reflectMapStringAnyType,
-		types.NullType:      reflect.TypeOf((*int)(nil)), // Any pointer will do.
 		types.StringType:    reflectStringType,
 		types.TimestampType: reflect.TypeOf(time.Time{}),
 		types.UintType:      reflect.TypeOf(uint64(0)),

--- a/testdata/json_encode.txt
+++ b/testdata/json_encode.txt
@@ -4,6 +4,7 @@ cmp stdout want.txt
 
 -- src.cel --
 [
+	null.encode_json(),
 	{"a":1, "b":[1, 2, 3]}.encode_json(),
 	encode_json({"a":1, "b":[1, 2, 3]}),
 	({
@@ -25,6 +26,7 @@ cmp stdout want.txt
 ]
 -- want.txt --
 [
+	"null",
 	"{\"a\":1,\"b\":[1,2,3]}",
 	"{\"a\":1,\"b\":[1,2,3]}",
 	"{\"a\":{\"b\":{\"c\":1}}}",


### PR DESCRIPTION
The previous code would fail with "internal error: json encode mapping out of sync: type conversion error from 'null_type' to '*int'".

Removing the entry from encodableTypes allows the conversion look-up to fall through to the relevant protobuf type.

Please take a look.