### PR TITLE
mito: add support for optional types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,14 @@ require (
 	aqwari.net/xml v0.0.0-20210331023308-d9421b293817
 	github.com/goccy/go-yaml v1.9.5
 	github.com/golang/protobuf v1.5.2
-	github.com/google/cel-go v0.15.3
+	github.com/google/cel-go v0.17.7
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
 	github.com/rogpeppe/go-internal v1.8.1
 	golang.org/x/oauth2 v0.7.0
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65
 	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37
-	google.golang.org/protobuf v1.28.1
+	google.golang.org/protobuf v1.31.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,14 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/google/cel-go v0.15.3 h1:W1wIeGuEs81+lBVU+cQRg1hkRT58Q6bNxvM5yn008S8=
-github.com/google/cel-go v0.15.3/go.mod h1:YzWEoI07MC/a/wj9in8GeVatqfypkldgBlwXh9bCwqY=
+github.com/google/cel-go v0.17.0 h1:o8fqHUcM+0g5prwg4pHZR+EMdef2RBumnEYefCXAyPQ=
+github.com/google/cel-go v0.17.0/go.mod h1:HXZKzB0LXqer5lHHgfWAnlYwJaQBDKMjxjulNQzhwhY=
+github.com/google/cel-go v0.17.1 h1:s2151PDGy/eqpCI80/8dl4VL3xTkqI/YubXLXCFw0mw=
+github.com/google/cel-go v0.17.1/go.mod h1:HXZKzB0LXqer5lHHgfWAnlYwJaQBDKMjxjulNQzhwhY=
+github.com/google/cel-go v0.17.7 h1:6ebJFzu1xO2n7TLtN+UBqShGBhlD85bhvglh5DpcfqQ=
+github.com/google/cel-go v0.17.7/go.mod h1:HXZKzB0LXqer5lHHgfWAnlYwJaQBDKMjxjulNQzhwhY=
+github.com/google/cel-go v0.18.1 h1:V/lAXKq4C3BYLDy/ARzMtpkEEYfHQpZzVyzy69nEUjs=
+github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcgC4zln4=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -97,8 +103,8 @@ google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 h1:jmIfw8+gSvXcZSg
 google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
-google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/lib/json.go
+++ b/lib/json.go
@@ -107,44 +107,44 @@ func (jsonLib) CompileOptions() []cel.EnvOption {
 			),
 			decls.NewFunction("decode_json",
 				decls.NewOverload(
-					"decode_json_string_or_bytes",
+					"decode_json_string",
 					[]*expr.Type{decls.String},
 					decls.Dyn,
 				),
 				decls.NewInstanceOverload(
-					"string_or_bytes_decode_json",
+					"string_decode_json",
 					[]*expr.Type{decls.String},
 					decls.Dyn,
 				),
 				decls.NewOverload(
-					"decode_json_string_or_bytes",
+					"decode_json_bytes",
 					[]*expr.Type{decls.Bytes},
 					decls.Dyn,
 				),
 				decls.NewInstanceOverload(
-					"string_or_bytes_decode_json",
+					"bytes_decode_json",
 					[]*expr.Type{decls.Bytes},
 					decls.Dyn,
 				),
 			),
 			decls.NewFunction("decode_json_stream",
 				decls.NewOverload(
-					"decode_json_stream_string_or_bytes",
+					"decode_json_stream_string",
 					[]*expr.Type{decls.String},
 					decls.NewListType(decls.Dyn),
 				),
 				decls.NewInstanceOverload(
-					"string_or_bytes_decode_json_stream",
+					"string_decode_json_stream",
 					[]*expr.Type{decls.String},
 					decls.NewListType(decls.Dyn),
 				),
 				decls.NewOverload(
-					"decode_json_stream_string_or_bytes",
+					"decode_json_stream_bytes",
 					[]*expr.Type{decls.Bytes},
 					decls.NewListType(decls.Dyn),
 				),
 				decls.NewInstanceOverload(
-					"string_or_bytes_decode_json_stream",
+					"bytes_decode_json_stream",
 					[]*expr.Type{decls.Bytes},
 					decls.NewListType(decls.Dyn),
 				),
@@ -167,21 +167,37 @@ func (l jsonLib) ProgramOptions() []cel.ProgramOption {
 		),
 		cel.Functions(
 			&functions.Overload{
-				Operator: "decode_json_string_or_bytes",
+				Operator: "decode_json_string",
 				Unary:    l.decodeJSON,
 			},
 			&functions.Overload{
-				Operator: "string_or_bytes_decode_json",
+				Operator: "decode_json_bytes",
+				Unary:    l.decodeJSON,
+			},
+			&functions.Overload{
+				Operator: "string_decode_json",
+				Unary:    l.decodeJSON,
+			},
+			&functions.Overload{
+				Operator: "bytes_decode_json",
 				Unary:    l.decodeJSON,
 			},
 		),
 		cel.Functions(
 			&functions.Overload{
-				Operator: "decode_json_stream_string_or_bytes",
+				Operator: "decode_json_stream_string",
 				Unary:    l.decodeJSONStream,
 			},
 			&functions.Overload{
-				Operator: "string_or_bytes_decode_json_stream",
+				Operator: "decode_json_stream_bytes",
+				Unary:    l.decodeJSONStream,
+			},
+			&functions.Overload{
+				Operator: "string_decode_json_stream",
+				Unary:    l.decodeJSONStream,
+			},
+			&functions.Overload{
+				Operator: "bytes_decode_json_stream",
 				Unary:    l.decodeJSONStream,
 			},
 		),

--- a/lib/types.go
+++ b/lib/types.go
@@ -28,6 +28,10 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+// OptionalTypesVersion is the version of the optional types library
+// used by mito.
+const OptionalTypesVersion = 1
+
 // Types used in overloads.
 var (
 	typeV        = decls.NewTypeParamType("V")

--- a/lib/types.go
+++ b/lib/types.go
@@ -55,7 +55,7 @@ var (
 		types.StringType:    reflectStringType,
 		types.TimestampType: reflect.TypeOf(time.Time{}),
 		types.UintType:      reflect.TypeOf(uint64(0)),
-		types.UnknownType:   reflect.TypeOf([]int64(types.Unknown(nil))), // Double conversion to catch type changes.
+		types.UnknownType:   reflect.TypeOf((*types.Unknown)(nil)),
 	}
 
 	// Linear search for proto.Message mappings and others.

--- a/lib/xml.go
+++ b/lib/xml.go
@@ -87,42 +87,42 @@ func (xmlLib) CompileOptions() []cel.EnvOption {
 		cel.Declarations(
 			decls.NewFunction("decode_xml",
 				decls.NewOverload(
-					"decode_xml_string_or_bytes",
+					"decode_xml_string",
 					[]*expr.Type{decls.String},
 					decls.Dyn,
 				),
 				decls.NewInstanceOverload(
-					"string_or_bytes_decode_xml",
+					"string_decode_xml",
 					[]*expr.Type{decls.String},
 					decls.Dyn,
 				),
 				decls.NewOverload(
-					"decode_xml_string_or_bytes",
+					"decode_xml_bytes",
 					[]*expr.Type{decls.Bytes},
 					decls.Dyn,
 				),
 				decls.NewInstanceOverload(
-					"string_or_bytes_decode_xml",
+					"bytes_decode_xml",
 					[]*expr.Type{decls.Bytes},
 					decls.Dyn,
 				),
 				decls.NewOverload(
-					"decode_xml_string_or_bytes_string",
+					"decode_xml_string_string",
 					[]*expr.Type{decls.String, decls.String},
 					decls.Dyn,
 				),
 				decls.NewInstanceOverload(
-					"string_or_bytes_decode_xml_string",
+					"string_decode_xml_string",
 					[]*expr.Type{decls.String, decls.String},
 					decls.Dyn,
 				),
 				decls.NewOverload(
-					"decode_xml_string_or_bytes_string",
+					"decode_xml_bytes_string",
 					[]*expr.Type{decls.Bytes, decls.String},
 					decls.Dyn,
 				),
 				decls.NewInstanceOverload(
-					"string_or_bytes_decode_xml_string",
+					"bytes_decode_xml_string",
 					[]*expr.Type{decls.Bytes, decls.String},
 					decls.Dyn,
 				),
@@ -135,19 +135,35 @@ func (l xmlLib) ProgramOptions() []cel.ProgramOption {
 	return []cel.ProgramOption{
 		cel.Functions(
 			&functions.Overload{
-				Operator: "decode_xml_string_or_bytes",
+				Operator: "decode_xml_string",
 				Unary:    l.decodeXML,
 			},
 			&functions.Overload{
-				Operator: "string_or_bytes_decode_xml",
+				Operator: "decode_xml_bytes",
 				Unary:    l.decodeXML,
 			},
 			&functions.Overload{
-				Operator: "decode_xml_string_or_bytes_string",
+				Operator: "string_decode_xml",
+				Unary:    l.decodeXML,
+			},
+			&functions.Overload{
+				Operator: "bytes_decode_xml",
+				Unary:    l.decodeXML,
+			},
+			&functions.Overload{
+				Operator: "decode_xml_string_string",
 				Binary:   l.decodeXMLWithXSD,
 			},
 			&functions.Overload{
-				Operator: "string_or_bytes_decode_xml_string",
+				Operator: "decode_xml_bytes_string",
+				Binary:   l.decodeXMLWithXSD,
+			},
+			&functions.Overload{
+				Operator: "string_decode_xml_string",
+				Binary:   l.decodeXMLWithXSD,
+			},
+			&functions.Overload{
+				Operator: "bytes_decode_xml_string",
 				Binary:   l.decodeXMLWithXSD,
 			},
 		),

--- a/mito.go
+++ b/mito.go
@@ -79,7 +79,9 @@ func Main() int {
 		return 2
 	}
 
-	var libs []cel.EnvOption
+	libs := []cel.EnvOption{
+		cel.OptionalTypes(cel.OptionalTypesVersion(lib.OptionalTypesVersion)),
+	}
 	if *cfgPath != "" {
 		f, err := os.Open(*cfgPath)
 		if err != nil {

--- a/testdata/optional_types.txt
+++ b/testdata/optional_types.txt
@@ -1,0 +1,14 @@
+mito -data state.json src.cel
+! stderr .
+cmp stdout want.txt
+
+-- state.json --
+{"n": 0}
+-- src.cel --
+{
+	"has_x_y_z": has(state.?x.?y.z),
+}
+-- want.txt --
+{
+	"has_x_y_z": false
+}


### PR DESCRIPTION
This brings support for optional types as described [here](https://pkg.go.dev/github.com/google/cel-go@v0.17.7/cel#OptionalTypes). For example (excerpted):
```
obj.?field.subfield
```
```
{?key: obj.?field.subfield}
```
and
```
[a, ?b, ?c] // return a list with either [a], [a, b], [a, b, c], or [a, c]
```

Point to consider: I've confirmed on the cel-discuss list that optional types are backwards compatible, so we could just have them always on, rather than configurable.

Please take a look.