### PR TITLE
Add a -max_executions flag and config option to limit evaluations

### DIFF
--- a/mito.go
+++ b/mito.go
@@ -67,6 +67,7 @@ func Main() int {
 	}
 	use := flag.String("use", "all", "libraries to use")
 	data := flag.String("data", "", "path to a JSON object holding input (exposed as the label "+root+")")
+	max := flag.Uint("max", 1000000, "maximum number of evaluations")
 	cfgPath := flag.String("cfg", "", "path to a YAML file holding configuration for global vars and regular expressions")
 	insecure := flag.Bool("insecure", false, "disable TLS verification in the HTTP client")
 	version := flag.Bool("version", false, "print version and exit")
@@ -183,7 +184,7 @@ func Main() int {
 		input = map[string]interface{}{root: input}
 	}
 
-	for {
+	for n := uint(0); n < *max; n++ {
 		res, val, err := eval(string(b), root, input, libs...)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/mito.go
+++ b/mito.go
@@ -145,6 +145,9 @@ func Main() int {
 				libMap["http"] = lib.HTTP(setClientInsecure(client, *insecure), nil, nil)
 			}
 		}
+		if *maxExecutions == -1 && cfg.MaxExecutions != nil {
+			*maxExecutions = *cfg.MaxExecutions
+		}
 	}
 	if libMap["http"] == nil {
 		libMap["http"] = lib.HTTP(setClientInsecure(nil, *insecure), nil, nil)
@@ -387,10 +390,11 @@ func toUpper(p []byte) {
 }
 
 type config struct {
-	Globals map[string]interface{} `yaml:"globals"`
-	Regexps map[string]string      `yaml:"regexp"`
-	XSDs    map[string]string      `yaml:"xsd"`
-	Auth    *authConfig            `yaml:"auth"`
+	Globals       map[string]interface{} `yaml:"globals"`
+	Regexps       map[string]string      `yaml:"regexp"`
+	XSDs          map[string]string      `yaml:"xsd"`
+	Auth          *authConfig            `yaml:"auth"`
+	MaxExecutions *int                   `yaml:"max_executions"`
 }
 
 type authConfig struct {

--- a/mito.go
+++ b/mito.go
@@ -67,7 +67,7 @@ func Main() int {
 	}
 	use := flag.String("use", "all", "libraries to use")
 	data := flag.String("data", "", "path to a JSON object holding input (exposed as the label "+root+")")
-	max := flag.Uint("max", 1000000, "maximum number of evaluations")
+	maxExecutions := flag.Uint("max_executions", 1000000, "maximum number of evaluations")
 	cfgPath := flag.String("cfg", "", "path to a YAML file holding configuration for global vars and regular expressions")
 	insecure := flag.Bool("insecure", false, "disable TLS verification in the HTTP client")
 	version := flag.Bool("version", false, "print version and exit")
@@ -184,7 +184,7 @@ func Main() int {
 		input = map[string]interface{}{root: input}
 	}
 
-	for n := uint(0); n < *max; n++ {
+	for n := uint(0); n < *maxExecutions; n++ {
 		res, val, err := eval(string(b), root, input, libs...)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/mito.go
+++ b/mito.go
@@ -67,7 +67,7 @@ func Main() int {
 	}
 	use := flag.String("use", "all", "libraries to use")
 	data := flag.String("data", "", "path to a JSON object holding input (exposed as the label "+root+")")
-	maxExecutions := flag.Uint("max_executions", 1000000, "maximum number of evaluations")
+	maxExecutions := flag.Int("max_executions", -1, "maximum number of evaluations, or no maximum if -1")
 	cfgPath := flag.String("cfg", "", "path to a YAML file holding configuration for global vars and regular expressions")
 	insecure := flag.Bool("insecure", false, "disable TLS verification in the HTTP client")
 	version := flag.Bool("version", false, "print version and exit")
@@ -184,7 +184,7 @@ func Main() int {
 		input = map[string]interface{}{root: input}
 	}
 
-	for n := uint(0); n < *maxExecutions; n++ {
+	for n := int(0); *maxExecutions < 0 || n < *maxExecutions; n++ {
 		res, val, err := eval(string(b), root, input, libs...)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/testdata/want_more_max.txt
+++ b/testdata/want_more_max.txt
@@ -1,0 +1,20 @@
+mito -data state.json -max 2 src.cel
+! stderr .
+cmp stdout want.txt
+
+-- state.json --
+{"n": 0}
+-- src.cel --
+int(state.n).as(n, {
+	"n":         n+1,
+	"want_more": n+1 < 5,
+})
+-- want.txt --
+{
+	"n": 1,
+	"want_more": true
+}
+{
+	"n": 2,
+	"want_more": true
+}

--- a/testdata/want_more_max.txt
+++ b/testdata/want_more_max.txt
@@ -1,4 +1,4 @@
-mito -data state.json -max 2 src.cel
+mito -data state.json -max_executions 2 src.cel
 ! stderr .
 cmp stdout want.txt
 


### PR DESCRIPTION
When many pages are available it's handy to be able to set a limit, especially for wrapper scripts.