### PR TITLE
lib: add base64 decode functions

### DIFF
--- a/lib/http.go
+++ b/lib/http.go
@@ -139,8 +139,9 @@ import (
 //
 // request returns a user-defined method request:
 //
-//	request(<string>, <string>, <string>, <bytes>) -> <map<string,dyn>>
-//	request(<string>, <string>, <string>, <string>) -> <map<string,dyn>>
+//	request(<string>, <string>) -> <map<string,dyn>>
+//	request(<string>, <string>, <bytes>) -> <map<string,dyn>>
+//	request(<string>, <string>, <string>) -> <map<string,dyn>>
 //
 // Example:
 //

--- a/testdata/base64.txt
+++ b/testdata/base64.txt
@@ -6,9 +6,13 @@ cmp stdout want.txt
 [
 	"hello world".base64(),
 	base64("hello world"),
+	string("aGVsbG8gd29ybGQ=".base64_decode()),
+	string(base64_decode("aGVsbG8gd29ybGQ=")),
 ]
 -- want.txt --
 [
 	"aGVsbG8gd29ybGQ=",
-	"aGVsbG8gd29ybGQ="
+	"aGVsbG8gd29ybGQ=",
+	"hello world",
+	"hello world"
 ]

--- a/testdata/base64_raw.txt
+++ b/testdata/base64_raw.txt
@@ -6,9 +6,13 @@ cmp stdout want.txt
 [
 	"hello world".base64_raw(),
 	base64_raw("hello world"),
+	string("aGVsbG8gd29ybGQ".base64_raw_decode()),
+	string(base64_raw_decode("aGVsbG8gd29ybGQ")),
 ]
 -- want.txt --
 [
 	"aGVsbG8gd29ybGQ",
-	"aGVsbG8gd29ybGQ"
+	"aGVsbG8gd29ybGQ",
+	"hello world",
+	"hello world"
 ]


### PR DESCRIPTION
This is one of those cases where in theory CEL and HTTPJSON were in parity, but in practice are not. This fixes that omission.

Please take a look.

Ref: elastic/integrations#9395