### PR TITLE
lib: update function definitions to new api

### DIFF
--- a/lib/collections.go
+++ b/lib/collections.go
@@ -23,16 +23,13 @@ import (
 	"strings"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
-	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/cel-go/parser"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // Collections returns a cel.EnvOption to configure extended functions for
@@ -168,6 +165,18 @@ import (
 //	[[1],[2,3],[[[4]],[5,6]]].flatten()                     // return [1, 2, 3, 4, 5, 6]
 //	[[{"a":1,"b":[10, 11]}],[2,3],[[[4]],[5,6]]].flatten()  // return [{"a":1, "b":[10, 11]}, 2, 3, 4, 5, 6]
 //
+// # Keys
+//
+// Returns a list of keys from a map:
+//
+//	keys(<map<dyn,dyn>>) -> <list<dyn>>
+//	<map<dyn,dyn>>.keys() -> <list<dyn>>
+//
+// Examples:
+//
+//	keys({"a":1, "b":2})   // return ["a", "b"]
+//	{1:"a", 2:"b"}.keys()   // return [1, 2]
+//
 // # Max
 //
 // Returns the maximum value of a list of comparable objects:
@@ -191,6 +200,18 @@ import (
 //
 //	[1,2,3,4,5,6,7].min()  // return 1
 //	min([1,2,3,4,5,6,7])   // return 1
+//
+// # Values
+//
+// Returns a list of values from a map:
+//
+//	values(<map<dyn,dyn>>) -> <list<dyn>>
+//	<map<dyn,dyn>>.values() -> <list<dyn>>
+//
+// Examples:
+//
+//	values({"a":1, "b":2})   // return [1, 2]
+//	{1:"a", 2:"b"}.values()   // return ["a", "b"]
 //
 // # With
 //
@@ -237,30 +258,6 @@ import (
 //
 //	zip(["a", "b"], [1, 2])  // return {"a":1, "b":2}
 //	["a", "b"].zip([1, 2])   // return {"a":1, "b":2}
-//
-// # Keys
-//
-// Returns a list of keys from a map:
-//
-//	keys(<map<dyn,dyn>>) -> <list<dyn>>
-//	<map<dyn,dyn>>.keys() -> <list<dyn>>
-//
-// Examples:
-//
-//	keys({"a":1, "b":2})   // return ["a", "b"]
-//	{1:"a", 2:"b"}.keys()   // return [1, 2]
-//
-// # Values
-//
-// Returns a list of values from a map:
-//
-//	values(<map<dyn,dyn>>) -> <list<dyn>>
-//	<map<dyn,dyn>>.values() -> <list<dyn>>
-//
-// Examples:
-//
-//	values({"a":1, "b":2})   // return [1, 2]
-//	{1:"a", 2:"b"}.values()   // return ["a", "b"]
 func Collections() cel.EnvOption {
 	return cel.Lib(collectionsLib{})
 }
@@ -270,292 +267,190 @@ type collectionsLib struct{}
 func (collectionsLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
 		cel.Macros(parser.NewReceiverMacro("as", 2, makeAs)),
-		cel.Declarations(
-			decls.NewFunction("collate",
-				decls.NewParameterizedInstanceOverload(
-					"list_collate_string",
-					[]*expr.Type{decls.NewListType(decls.Dyn), decls.String},
-					listV,
-					[]string{"V"},
-				),
-				decls.NewParameterizedInstanceOverload(
-					"list_collate_list_string",
-					[]*expr.Type{decls.NewListType(decls.Dyn), decls.NewListType(decls.String)},
-					listV,
-					[]string{"V"},
-				),
-				decls.NewParameterizedInstanceOverload(
-					"map_collate_string",
-					[]*expr.Type{mapStringDyn, decls.String},
-					listV,
-					[]string{"V"},
-				),
-				decls.NewParameterizedInstanceOverload(
-					"map_collate_list_string",
-					[]*expr.Type{mapStringDyn, decls.NewListType(decls.String)},
-					listV,
-					[]string{"V"},
-				),
+
+		cel.Function("collate",
+			cel.MemberOverload(
+				"list_collate_string",
+				[]*cel.Type{listDyn, cel.StringType},
+				listDyn,
+				cel.BinaryBinding(collateFields),
 			),
-			decls.NewFunction("drop",
-				decls.NewInstanceOverload(
-					"list_drop_string",
-					[]*expr.Type{decls.NewListType(decls.Dyn), decls.String},
-					decls.NewListType(decls.Dyn),
-				),
-				decls.NewInstanceOverload(
-					"list_drop_list_string",
-					[]*expr.Type{decls.NewListType(decls.Dyn), decls.NewListType(decls.String)},
-					decls.NewListType(decls.Dyn),
-				),
-				decls.NewInstanceOverload(
-					"map_drop_string",
-					[]*expr.Type{mapKV, decls.String},
-					mapKV,
-				),
-				decls.NewInstanceOverload(
-					"map_drop_list_string",
-					[]*expr.Type{mapKV, decls.NewListType(decls.String)},
-					mapKV,
-				),
+			cel.MemberOverload(
+				"list_collate_list_string",
+				[]*cel.Type{listDyn, listString},
+				listDyn,
+				cel.BinaryBinding(collateFields),
 			),
-			decls.NewFunction("drop_empty",
-				decls.NewInstanceOverload(
-					"list_drop_empty",
-					[]*expr.Type{decls.NewListType(decls.Dyn)},
-					decls.NewListType(decls.Dyn),
-				),
-				decls.NewInstanceOverload(
-					"map_drop_empty",
-					[]*expr.Type{mapKV},
-					mapKV,
-				),
+			cel.MemberOverload(
+				"map_collate_string",
+				[]*cel.Type{mapStringDyn, cel.StringType},
+				listDyn,
+				cel.BinaryBinding(collateFields),
 			),
-			decls.NewFunction("flatten",
-				decls.NewInstanceOverload(
-					"list_flatten",
-					[]*expr.Type{decls.NewListType(decls.Dyn)},
-					decls.NewListType(decls.Dyn),
-				),
+			cel.MemberOverload(
+				"map_collate_list_string",
+				[]*cel.Type{mapStringDyn, listString},
+				listDyn,
+				cel.BinaryBinding(collateFields),
 			),
-			decls.NewFunction("max",
-				decls.NewParameterizedInstanceOverload(
-					"list_max",
-					[]*expr.Type{listV},
-					typeV,
-					[]string{"V"},
-				),
-				decls.NewParameterizedOverload(
-					"max_list",
-					[]*expr.Type{listV},
-					typeV,
-					[]string{"V"},
-				),
+		),
+
+		cel.Function("drop",
+			cel.MemberOverload(
+				"list_drop_string",
+				[]*cel.Type{listV, cel.StringType},
+				listV,
+				cel.BinaryBinding(dropFields),
 			),
-			decls.NewFunction("min",
-				decls.NewParameterizedInstanceOverload(
-					"list_min",
-					[]*expr.Type{listV},
-					typeV,
-					[]string{"V"},
-				),
-				decls.NewParameterizedOverload(
-					"min_list",
-					[]*expr.Type{listV},
-					typeV,
-					[]string{"V"},
-				),
+			cel.MemberOverload(
+				"list_drop_list_string",
+				[]*cel.Type{listV, listString},
+				listV,
+				cel.BinaryBinding(dropFields),
 			),
-			decls.NewFunction("with",
-				decls.NewParameterizedInstanceOverload(
-					"map_with_map",
-					[]*expr.Type{mapKV, mapKV},
-					mapKV,
-					[]string{"K", "V"},
-				),
+			cel.MemberOverload(
+				"map_drop_string",
+				[]*cel.Type{mapKV, cel.StringType},
+				mapKV,
+				cel.BinaryBinding(dropFields),
 			),
-			decls.NewFunction("with_update",
-				decls.NewParameterizedInstanceOverload(
-					"map_with_update_map",
-					[]*expr.Type{mapKV, mapKV},
-					mapKV,
-					[]string{"K", "V"},
-				),
+			cel.MemberOverload(
+				"map_drop_list_string",
+				[]*cel.Type{mapKV, listString},
+				mapKV,
+				cel.BinaryBinding(dropFields),
 			),
-			decls.NewFunction("with_replace",
-				decls.NewParameterizedInstanceOverload(
-					"map_with_replace_map",
-					[]*expr.Type{mapKV, mapKV},
-					mapKV,
-					[]string{"K", "V"},
-				),
+		),
+
+		cel.Function("drop_empty",
+			cel.MemberOverload(
+				"list_drop_empty",
+				[]*cel.Type{listV},
+				listV,
+				cel.UnaryBinding(dropEmpty),
 			),
-			decls.NewFunction("zip",
-				decls.NewParameterizedInstanceOverload(
-					"list_zip",
-					[]*expr.Type{listK, listV},
-					mapKV,
-					[]string{"K", "V"},
-				),
-				decls.NewParameterizedOverload(
-					"zip_list",
-					[]*expr.Type{listK, listV},
-					mapKV,
-					[]string{"K", "V"},
-				),
+			cel.MemberOverload(
+				"map_drop_empty",
+				[]*cel.Type{mapKV},
+				mapKV,
+				cel.UnaryBinding(dropEmpty),
 			),
-			decls.NewFunction("keys",
-				decls.NewParameterizedInstanceOverload(
-					"map_keys",
-					[]*expr.Type{mapKV},
-					listK,
-					[]string{"K"},
-				),
-				decls.NewParameterizedOverload(
-					"keys_map",
-					[]*expr.Type{mapKV},
-					listK,
-					[]string{"K"},
-				),
+		),
+
+		cel.Function("flatten",
+			cel.MemberOverload(
+				"list_flatten",
+				[]*cel.Type{listV},
+				listV,
+				cel.UnaryBinding(flatten),
 			),
-			decls.NewFunction("values",
-				decls.NewParameterizedInstanceOverload(
-					"map_values",
-					[]*expr.Type{mapKV},
-					listV,
-					[]string{"V"},
-				),
-				decls.NewParameterizedOverload(
-					"values_map",
-					[]*expr.Type{mapKV},
-					listV,
-					[]string{"V"},
-				),
+		),
+
+		cel.Function("keys",
+			cel.MemberOverload(
+				"map_keys",
+				[]*cel.Type{mapKV},
+				listK,
+				cel.UnaryBinding(mapKeys),
+			),
+			cel.Overload(
+				"keys_map",
+				[]*cel.Type{mapKV},
+				listK,
+				cel.UnaryBinding(mapKeys),
+			),
+		),
+
+		cel.Function("max",
+			cel.MemberOverload(
+				"list_max",
+				[]*cel.Type{listV},
+				typeV,
+				cel.UnaryBinding(max),
+			),
+			cel.Overload(
+				"max_list",
+				[]*cel.Type{listV},
+				typeV,
+				cel.UnaryBinding(max),
+			),
+		),
+
+		cel.Function("min",
+			cel.MemberOverload(
+				"list_min",
+				[]*cel.Type{listV},
+				typeV,
+				cel.UnaryBinding(min),
+			),
+			cel.Overload(
+				"min_list",
+				[]*cel.Type{listV},
+				typeV,
+				cel.UnaryBinding(min),
+			),
+		),
+
+		cel.Function("values",
+			cel.MemberOverload(
+				"map_values",
+				[]*cel.Type{mapKV},
+				listK,
+				cel.UnaryBinding(mapValues),
+			),
+			cel.Overload(
+				"values_map",
+				[]*cel.Type{mapKV},
+				listK,
+				cel.UnaryBinding(mapValues),
+			),
+		),
+
+		cel.Function("with",
+			cel.MemberOverload(
+				"map_with_map",
+				[]*cel.Type{mapKV, mapKV},
+				mapKV,
+				cel.BinaryBinding(withAll),
+			),
+		),
+
+		cel.Function("with_update",
+			cel.MemberOverload(
+				"map_with_update_map",
+				[]*cel.Type{mapKV, mapKV},
+				mapKV,
+				cel.BinaryBinding(withUpdate),
+			),
+		),
+
+		cel.Function("with_replace",
+			cel.MemberOverload(
+				"map_with_replace_map",
+				[]*cel.Type{mapKV, mapKV},
+				mapKV,
+				cel.BinaryBinding(withReplace),
+			),
+		),
+
+		cel.Function("zip",
+			cel.MemberOverload(
+				"list_zip",
+				[]*cel.Type{listK, listV},
+				mapKV,
+				cel.BinaryBinding(zipLists),
+			),
+			cel.Overload(
+				"zip_list",
+				[]*cel.Type{listK, listV},
+				mapKV,
+				cel.BinaryBinding(zipLists),
 			),
 		),
 	}
 }
 
-func (collectionsLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator: "list_collate_string",
-				Binary:   collateFields,
-			},
-			&functions.Overload{
-				Operator: "list_collate_list_string",
-				Binary:   collateFields,
-			},
-			&functions.Overload{
-				Operator: "map_collate_string",
-				Binary:   collateFields,
-			},
-			&functions.Overload{
-				Operator: "map_collate_list_string",
-				Binary:   collateFields,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "list_drop_string",
-				Binary:   dropFields,
-			},
-			&functions.Overload{
-				Operator: "list_drop_list_string",
-				Binary:   dropFields,
-			},
-			&functions.Overload{
-				Operator: "map_drop_string",
-				Binary:   dropFields,
-			},
-			&functions.Overload{
-				Operator: "map_drop_list_string",
-				Binary:   dropFields,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "list_drop_empty",
-				Unary:    dropEmpty,
-			},
-			&functions.Overload{
-				Operator: "map_drop_empty",
-				Unary:    dropEmpty,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "list_flatten",
-				Unary:    flatten,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "min_list",
-				Unary:    min,
-			},
-			&functions.Overload{
-				Operator: "list_min",
-				Unary:    min,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "max_list",
-				Unary:    max,
-			},
-			&functions.Overload{
-				Operator: "list_max",
-				Unary:    max,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "map_with_map",
-				Binary:   withAll,
-			},
-			&functions.Overload{
-				Operator: "map_with_update_map",
-				Binary:   withUpdate,
-			},
-			&functions.Overload{
-				Operator: "map_with_replace_map",
-				Binary:   withReplace,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "zip_list",
-				Binary:   zipLists,
-			},
-			&functions.Overload{
-				Operator: "list_zip",
-				Binary:   zipLists,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "map_keys",
-				Unary:    mapKeys,
-			},
-			&functions.Overload{
-				Operator: "keys_map",
-				Unary:    mapKeys,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "map_values",
-				Unary:    mapValues,
-			},
-			&functions.Overload{
-				Operator: "values_map",
-				Unary:    mapValues,
-			},
-		),
-	}
-}
+func (collectionsLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func flatten(arg ref.Val) ref.Val {
 	obj := arg

--- a/lib/crypto.go
+++ b/lib/crypto.go
@@ -27,12 +27,9 @@ import (
 	"hash"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/uuid"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // Crypto returns a cel.EnvOption to configure extended functions for
@@ -174,352 +171,237 @@ type cryptoLib struct{}
 
 func (cryptoLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Declarations(
-			decls.NewFunction("base64",
-				decls.NewOverload(
-					"base64_bytes",
-					[]*expr.Type{decls.Bytes},
-					decls.String,
-				),
-				decls.NewInstanceOverload(
-					"bytes_base64",
-					[]*expr.Type{decls.Bytes},
-					decls.String,
-				),
-				decls.NewOverload(
-					"base64_string",
-					[]*expr.Type{decls.String},
-					decls.String,
-				),
-				decls.NewInstanceOverload(
-					"string_base64",
-					[]*expr.Type{decls.String},
-					decls.String,
-				),
+		cel.Function("base64",
+			cel.MemberOverload(
+				"bytes_base64",
+				[]*cel.Type{cel.BytesType},
+				cel.StringType,
+				cel.UnaryBinding(base64Encode),
 			),
-			decls.NewFunction("base64_decode",
-				decls.NewOverload(
-					"base64_decode_string",
-					[]*expr.Type{decls.String},
-					decls.Bytes,
-				),
-				decls.NewInstanceOverload(
-					"string_base64_decode",
-					[]*expr.Type{decls.String},
-					decls.Bytes,
-				),
+			cel.Overload(
+				"base64_bytes",
+				[]*cel.Type{cel.BytesType},
+				cel.StringType,
+				cel.UnaryBinding(base64Encode),
 			),
-			decls.NewFunction("base64_raw",
-				decls.NewOverload(
-					"base64_raw_bytes",
-					[]*expr.Type{decls.Bytes},
-					decls.String,
-				),
-				decls.NewInstanceOverload(
-					"bytes_base64_raw",
-					[]*expr.Type{decls.Bytes},
-					decls.String,
-				),
-				decls.NewOverload(
-					"base64_raw_string",
-					[]*expr.Type{decls.String},
-					decls.String,
-				),
-				decls.NewInstanceOverload(
-					"string_base64_raw",
-					[]*expr.Type{decls.String},
-					decls.String,
-				),
+			cel.MemberOverload(
+				"string_base64",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(base64Encode),
 			),
-			decls.NewFunction("base64_raw_decode",
-				decls.NewOverload(
-					"base64_raw_decode_string",
-					[]*expr.Type{decls.String},
-					decls.Bytes,
-				),
-				decls.NewInstanceOverload(
-					"string_base64_raw_decode",
-					[]*expr.Type{decls.String},
-					decls.Bytes,
-				),
+			cel.Overload(
+				"base64_string",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(base64Encode),
 			),
-			decls.NewFunction("hex",
-				decls.NewOverload(
-					"hex_bytes",
-					[]*expr.Type{decls.Bytes},
-					decls.String,
-				),
-				decls.NewInstanceOverload(
-					"bytes_hex",
-					[]*expr.Type{decls.Bytes},
-					decls.String,
-				),
-				decls.NewOverload(
-					"hex_string",
-					[]*expr.Type{decls.String},
-					decls.String,
-				),
-				decls.NewInstanceOverload(
-					"string_hex",
-					[]*expr.Type{decls.String},
-					decls.String,
-				),
+		),
+
+		cel.Function("base64_decode",
+			cel.MemberOverload(
+				"string_base64_decode",
+				[]*cel.Type{cel.StringType},
+				cel.BytesType,
+				cel.UnaryBinding(base64Decode),
 			),
-			decls.NewFunction("md5",
-				decls.NewOverload(
-					"md5_bytes",
-					[]*expr.Type{decls.Bytes},
-					decls.Bytes,
-				),
-				decls.NewInstanceOverload(
-					"bytes_md5",
-					[]*expr.Type{decls.Bytes},
-					decls.Bytes,
-				),
-				decls.NewOverload(
-					"md5_string",
-					[]*expr.Type{decls.String},
-					decls.Bytes,
-				),
-				decls.NewInstanceOverload(
-					"string_md5",
-					[]*expr.Type{decls.String},
-					decls.Bytes,
-				),
+			cel.Overload(
+				"base64_decode_string",
+				[]*cel.Type{cel.StringType},
+				cel.BytesType,
+				cel.UnaryBinding(base64Decode),
 			),
-			decls.NewFunction("sha1",
-				decls.NewOverload(
-					"sha1_bytes",
-					[]*expr.Type{decls.Bytes},
-					decls.Bytes,
-				),
-				decls.NewInstanceOverload(
-					"bytes_sha1",
-					[]*expr.Type{decls.Bytes},
-					decls.Bytes,
-				),
-				decls.NewOverload(
-					"sha1_string",
-					[]*expr.Type{decls.String},
-					decls.Bytes,
-				),
-				decls.NewInstanceOverload(
-					"string_sha1",
-					[]*expr.Type{decls.String},
-					decls.Bytes,
-				),
+		),
+
+		cel.Function("base64_raw",
+			cel.MemberOverload(
+				"bytes_base64_raw",
+				[]*cel.Type{cel.BytesType},
+				cel.StringType,
+				cel.UnaryBinding(base64RawEncode),
 			),
-			decls.NewFunction("sha256",
-				decls.NewOverload(
-					"sha256_bytes",
-					[]*expr.Type{decls.Bytes},
-					decls.Bytes,
-				),
-				decls.NewInstanceOverload(
-					"bytes_sha256",
-					[]*expr.Type{decls.Bytes},
-					decls.Bytes,
-				),
-				decls.NewOverload(
-					"sha256_string",
-					[]*expr.Type{decls.String},
-					decls.Bytes,
-				),
-				decls.NewInstanceOverload(
-					"string_sha256",
-					[]*expr.Type{decls.String},
-					decls.Bytes,
-				),
+			cel.Overload(
+				"base64_raw_bytes",
+				[]*cel.Type{cel.BytesType},
+				cel.StringType,
+				cel.UnaryBinding(base64RawEncode),
 			),
-			decls.NewFunction("hmac",
-				decls.NewOverload(
-					"hmac_bytes_string_bytes",
-					[]*expr.Type{decls.Bytes, decls.String, decls.Bytes},
-					decls.Bytes,
-				),
-				decls.NewInstanceOverload(
-					"bytes_hmac_string_bytes",
-					[]*expr.Type{decls.Bytes, decls.String, decls.Bytes},
-					decls.Bytes,
-				),
-				decls.NewOverload(
-					"hmac_string_string_bytes",
-					[]*expr.Type{decls.String, decls.String, decls.Bytes},
-					decls.Bytes,
-				),
-				decls.NewInstanceOverload(
-					"string_hmac_string_bytes",
-					[]*expr.Type{decls.String, decls.String, decls.Bytes},
-					decls.Bytes,
-				),
+			cel.MemberOverload(
+				"string_base64_raw",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(base64RawEncode),
 			),
-			decls.NewFunction("uuid",
-				decls.NewOverload(
-					"uuid_string",
-					nil,
-					decls.String,
-				),
+			cel.Overload(
+				"base64_raw_string",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(base64RawEncode),
+			),
+		),
+
+		cel.Function("base64_raw_decode",
+			cel.MemberOverload(
+				"string_base64_raw_decode",
+				[]*cel.Type{cel.StringType},
+				cel.BytesType,
+				cel.UnaryBinding(base64RawDecode),
+			),
+			cel.Overload(
+				"base64_raw_decode_string",
+				[]*cel.Type{cel.StringType},
+				cel.BytesType,
+				cel.UnaryBinding(base64RawDecode),
+			),
+		),
+
+		cel.Function("hex",
+			cel.MemberOverload(
+				"bytes_hex",
+				[]*cel.Type{cel.BytesType},
+				cel.StringType,
+				cel.UnaryBinding(hexEncode),
+			),
+			cel.Overload(
+				"hex_bytes",
+				[]*cel.Type{cel.BytesType},
+				cel.StringType,
+				cel.UnaryBinding(hexEncode),
+			),
+			cel.MemberOverload(
+				"string_hex",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(hexEncode),
+			),
+			cel.Overload(
+				"hex_string",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(hexEncode),
+			),
+		),
+
+		cel.Function("md5",
+			cel.MemberOverload(
+				"bytes_md5",
+				[]*cel.Type{cel.BytesType},
+				cel.BytesType,
+				cel.UnaryBinding(md5Hash),
+			),
+			cel.Overload(
+				"md5_bytes",
+				[]*cel.Type{cel.BytesType},
+				cel.BytesType,
+				cel.UnaryBinding(md5Hash),
+			),
+			cel.MemberOverload(
+				"string_md5",
+				[]*cel.Type{cel.StringType},
+				cel.BytesType,
+				cel.UnaryBinding(md5Hash),
+			),
+			cel.Overload(
+				"md5_string",
+				[]*cel.Type{cel.StringType},
+				cel.BytesType,
+				cel.UnaryBinding(md5Hash),
+			),
+		),
+
+		cel.Function("sha1",
+			cel.MemberOverload(
+				"bytes_sha1",
+				[]*cel.Type{cel.BytesType},
+				cel.BytesType,
+				cel.UnaryBinding(sha1Hash),
+			),
+			cel.Overload(
+				"sha1_bytes",
+				[]*cel.Type{cel.BytesType},
+				cel.BytesType,
+				cel.UnaryBinding(sha1Hash),
+			),
+			cel.MemberOverload(
+				"string_sha1",
+				[]*cel.Type{cel.StringType},
+				cel.BytesType,
+				cel.UnaryBinding(sha1Hash),
+			),
+			cel.Overload(
+				"sha1_string",
+				[]*cel.Type{cel.StringType},
+				cel.BytesType,
+				cel.UnaryBinding(sha1Hash),
+			),
+		),
+
+		cel.Function("sha256",
+			cel.MemberOverload(
+				"bytes_sha256",
+				[]*cel.Type{cel.BytesType},
+				cel.BytesType,
+				cel.UnaryBinding(sha256Hash),
+			),
+			cel.Overload(
+				"sha256_bytes",
+				[]*cel.Type{cel.BytesType},
+				cel.BytesType,
+				cel.UnaryBinding(sha256Hash),
+			),
+			cel.MemberOverload(
+				"string_sha256",
+				[]*cel.Type{cel.StringType},
+				cel.BytesType,
+				cel.UnaryBinding(sha256Hash),
+			),
+			cel.Overload(
+				"sha256_string",
+				[]*cel.Type{cel.StringType},
+				cel.BytesType,
+				cel.UnaryBinding(sha256Hash),
+			),
+		),
+
+		cel.Function("hmac",
+			cel.MemberOverload(
+				"bytes_hmac_string_bytes",
+				[]*cel.Type{cel.BytesType, cel.StringType, cel.BytesType},
+				cel.BytesType,
+				cel.FunctionBinding(hmacHash),
+			),
+			cel.Overload(
+				"hmac_bytes_string_bytes",
+				[]*cel.Type{cel.BytesType, cel.StringType, cel.BytesType},
+				cel.BytesType,
+				cel.FunctionBinding(hmacHash),
+			),
+			cel.MemberOverload(
+				"string_hmac_string_bytes",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.BytesType},
+				cel.BytesType,
+				cel.FunctionBinding(hmacHash),
+			),
+			cel.Overload(
+				"hmac_string_string_bytes",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.BytesType},
+				cel.BytesType,
+				cel.FunctionBinding(hmacHash),
+			),
+		),
+
+		cel.Function("uuid",
+			cel.Overload(
+				"uuid_string",
+				nil,
+				cel.StringType,
+				cel.FunctionBinding(uuidString),
 			),
 		),
 	}
 }
 
-func (cryptoLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator: "base64_bytes",
-				Unary:    base64Encode,
-			},
-			&functions.Overload{
-				Operator: "bytes_base64",
-				Unary:    base64Encode,
-			},
-			&functions.Overload{
-				Operator: "base64_string",
-				Unary:    base64Encode,
-			},
-			&functions.Overload{
-				Operator: "string_base64",
-				Unary:    base64Encode,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "base64_decode_string",
-				Unary:    base64Decode,
-			},
-			&functions.Overload{
-				Operator: "string_base64_decode",
-				Unary:    base64Decode,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "base64_raw_bytes",
-				Unary:    base64RawEncode,
-			},
-			&functions.Overload{
-				Operator: "bytes_base64_raw",
-				Unary:    base64RawEncode,
-			},
-			&functions.Overload{
-				Operator: "base64_raw_string",
-				Unary:    base64RawEncode,
-			},
-			&functions.Overload{
-				Operator: "string_base64_raw",
-				Unary:    base64RawEncode,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "base64_raw_decode_string",
-				Unary:    base64RawDecode,
-			},
-			&functions.Overload{
-				Operator: "string_base64_raw_decode",
-				Unary:    base64RawDecode,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "hex_bytes",
-				Unary:    hexEncode,
-			},
-			&functions.Overload{
-				Operator: "bytes_hex",
-				Unary:    hexEncode,
-			},
-			&functions.Overload{
-				Operator: "hex_string",
-				Unary:    hexEncode,
-			},
-			&functions.Overload{
-				Operator: "string_hex",
-				Unary:    hexEncode,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "md5_bytes",
-				Unary:    md5Hash,
-			},
-			&functions.Overload{
-				Operator: "bytes_md5",
-				Unary:    md5Hash,
-			},
-			&functions.Overload{
-				Operator: "md5_string",
-				Unary:    md5Hash,
-			},
-			&functions.Overload{
-				Operator: "string_md5",
-				Unary:    md5Hash,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "sha1_bytes",
-				Unary:    sha1Hash,
-			},
-			&functions.Overload{
-				Operator: "bytes_sha1",
-				Unary:    sha1Hash,
-			},
-			&functions.Overload{
-				Operator: "sha1_string",
-				Unary:    sha1Hash,
-			},
-			&functions.Overload{
-				Operator: "string_sha1",
-				Unary:    sha1Hash,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "sha256_bytes",
-				Unary:    sha256Hash,
-			},
-			&functions.Overload{
-				Operator: "bytes_sha256",
-				Unary:    sha256Hash,
-			},
-			&functions.Overload{
-				Operator: "sha256_string",
-				Unary:    sha256Hash,
-			},
-			&functions.Overload{
-				Operator: "string_sha256",
-				Unary:    sha256Hash,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "hmac_bytes_string_bytes",
-				Function: hmacHash,
-			},
-			&functions.Overload{
-				Operator: "bytes_hmac_string_bytes",
-				Function: hmacHash,
-			},
-			&functions.Overload{
-				Operator: "hmac_string_string_bytes",
-				Function: hmacHash,
-			},
-			&functions.Overload{
-				Operator: "string_hmac_string_bytes",
-				Function: hmacHash,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "uuid_string",
-				Function: uuidString,
-			},
-		),
-	}
-}
+func (cryptoLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func base64Encode(val ref.Val) ref.Val {
 	switch val := val.(type) {

--- a/lib/file.go
+++ b/lib/file.go
@@ -24,11 +24,8 @@ import (
 	"sort"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/interpreter/functions"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // File returns a cel.EnvOption to configure extended functions for reading files.
@@ -110,52 +107,34 @@ type fileLib struct {
 	transforms map[string]interface{}
 }
 
-func (fileLib) CompileOptions() []cel.EnvOption {
+func (l fileLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Declarations(
-			decls.NewFunction("dir",
-				decls.NewOverload(
-					"dir_string",
-					[]*expr.Type{decls.String},
-					decls.NewListType(decls.NewMapType(decls.String, decls.Dyn)),
-				),
+		cel.Function("dir",
+			cel.Overload(
+				"dir_string",
+				[]*cel.Type{cel.StringType},
+				cel.ListType(mapStringDyn),
+				cel.UnaryBinding(readDir),
 			),
-			decls.NewFunction("file",
-				decls.NewOverload(
-					"file_string",
-					[]*expr.Type{decls.String},
-					decls.Bytes,
-				),
-				decls.NewOverload(
-					"file_string_string",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Dyn,
-				),
+		),
+		cel.Function("file",
+			cel.Overload(
+				"file_string",
+				[]*cel.Type{cel.StringType},
+				cel.BytesType,
+				cel.UnaryBinding(readFile),
+			),
+			cel.Overload(
+				"file_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.DynType,
+				cel.BinaryBinding(l.readMIMEFile),
 			),
 		),
 	}
 }
 
-func (l fileLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator: "dir_string",
-				Unary:    readDir,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "file_string",
-				Unary:    readFile,
-			},
-			&functions.Overload{
-				Operator: "file_string_string",
-				Binary:   l.readMIMEFile,
-			},
-		),
-	}
-}
+func (fileLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func readDir(arg ref.Val) ref.Val {
 	path, ok := arg.(types.String)

--- a/lib/http.go
+++ b/lib/http.go
@@ -29,13 +29,10 @@ import (
 	"strings"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
-	"github.com/google/cel-go/interpreter/functions"
 	"golang.org/x/time/rate"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // HTTP returns a cel.EnvOption to configure extended functions for HTTP
@@ -312,209 +309,139 @@ type BasicAuth struct {
 	Username, Password string
 }
 
-func (httpLib) CompileOptions() []cel.EnvOption {
+func (l httpLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Declarations(
-			decls.NewFunction("head",
-				decls.NewOverload(
-					"head_string",
-					[]*expr.Type{decls.String},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
+		cel.Function("head",
+			cel.Overload(
+				"head_string",
+				[]*cel.Type{cel.StringType},
+				mapStringDyn,
+				cel.UnaryBinding(l.doHead),
 			),
-			decls.NewFunction("get",
-				decls.NewOverload(
-					"get_string",
-					[]*expr.Type{decls.String},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
+		),
+
+		cel.Function("get",
+			cel.Overload(
+				"get_string",
+				[]*cel.Type{cel.StringType},
+				mapStringDyn,
+				cel.UnaryBinding(l.doGet),
 			),
-			decls.NewFunction("get_request",
-				decls.NewOverload(
-					"get_request_string",
-					[]*expr.Type{decls.String},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
+		),
+		cel.Function("get_request",
+			cel.Overload(
+				"get_request_string",
+				[]*cel.Type{cel.StringType},
+				mapStringDyn,
+				cel.UnaryBinding(newGetRequest),
 			),
-			decls.NewFunction("post",
-				decls.NewOverload(
-					"post_string_string_bytes",
-					[]*expr.Type{decls.String, decls.String, decls.Bytes},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
-				decls.NewOverload(
-					"post_string_string_string",
-					[]*expr.Type{decls.String, decls.String, decls.String},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
+		),
+
+		cel.Function("post",
+			cel.Overload(
+				"post_string_string_bytes",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.BytesType},
+				mapStringDyn,
+				cel.FunctionBinding(l.doPost),
 			),
-			decls.NewFunction("post_request",
-				decls.NewOverload(
-					"post_request_string_string_bytes",
-					[]*expr.Type{decls.String, decls.String, decls.Bytes},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
-				decls.NewOverload(
-					"post_request_string_string_string",
-					[]*expr.Type{decls.String, decls.String, decls.String},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
+			cel.Overload(
+				"post_string_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.StringType},
+				mapStringDyn,
+				cel.FunctionBinding(l.doPost),
 			),
-			decls.NewFunction("request",
-				decls.NewOverload(
-					"request_string_string",
-					[]*expr.Type{decls.String, decls.String},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
-				decls.NewOverload(
-					"request_string_string_bytes",
-					[]*expr.Type{decls.String, decls.String, decls.Bytes},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
-				decls.NewOverload(
-					"request_string_string_string",
-					[]*expr.Type{decls.String, decls.String, decls.String},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
+		),
+		cel.Function("post_request",
+			cel.Overload(
+				"post_request_string_string_bytes",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.BytesType},
+				mapStringDyn,
+				cel.FunctionBinding(newPostRequest),
 			),
-			decls.NewFunction("basic_authentication",
-				decls.NewInstanceOverload(
-					"map_basic_authentication_string_string",
-					[]*expr.Type{decls.NewMapType(decls.String, decls.Dyn), decls.String, decls.String},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
+			cel.Overload(
+				"post_request_string_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.StringType},
+				mapStringDyn,
+				cel.FunctionBinding(newPostRequest),
 			),
-			decls.NewFunction("do_request",
-				decls.NewInstanceOverload(
-					"map_do_request",
-					[]*expr.Type{decls.NewMapType(decls.String, decls.Dyn)},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
+		),
+
+		cel.Function("request",
+			cel.Overload(
+				"request_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				mapStringDyn,
+				cel.BinaryBinding(newRequest),
 			),
-			decls.NewFunction("parse_url",
-				decls.NewInstanceOverload(
-					"string_parse_url",
-					[]*expr.Type{decls.String},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
+			cel.Overload(
+				"request_string_string_bytes",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.BytesType},
+				mapStringDyn,
+				cel.FunctionBinding(newRequestBody),
 			),
-			decls.NewFunction("format_url",
-				decls.NewInstanceOverload(
-					"map_format_url",
-					[]*expr.Type{decls.NewMapType(decls.String, decls.Dyn)},
-					decls.String,
-				),
+			cel.Overload(
+				"request_string_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.StringType},
+				mapStringDyn,
+				cel.FunctionBinding(newRequestBody),
 			),
-			decls.NewFunction("parse_query",
-				decls.NewInstanceOverload(
-					"string_parse_query",
-					[]*expr.Type{decls.String},
-					decls.NewMapType(decls.String, decls.NewListType(decls.String)),
-				),
+		),
+
+		cel.Function("do_request",
+			cel.MemberOverload(
+				"map_do_request",
+				[]*cel.Type{mapStringDyn},
+				mapStringDyn,
+				cel.UnaryBinding(l.doRequest),
 			),
-			decls.NewFunction("format_query",
-				decls.NewInstanceOverload(
-					"map_format_query",
-					[]*expr.Type{decls.NewMapType(decls.String, decls.NewListType(decls.String))},
-					decls.String,
-				),
+		),
+
+		cel.Function("basic_authentication",
+			cel.MemberOverload(
+				"map_basic_authentication_string_string",
+				[]*cel.Type{mapStringDyn, cel.StringType, cel.StringType},
+				mapStringDyn,
+				cel.FunctionBinding(l.basicAuthentication),
+			),
+		),
+
+		cel.Function("parse_url",
+			cel.MemberOverload(
+				"string_parse_url",
+				[]*cel.Type{cel.StringType},
+				mapStringDyn,
+				cel.UnaryBinding(parseURL),
+			),
+		),
+		cel.Function("format_url",
+			cel.MemberOverload(
+				"map_format_url",
+				[]*cel.Type{mapStringDyn},
+				cel.StringType,
+				cel.UnaryBinding(formatURL),
+			),
+		),
+
+		cel.Function("parse_query",
+			cel.MemberOverload(
+				"string_parse_query",
+				[]*cel.Type{cel.StringType},
+				mapStringDyn,
+				cel.UnaryBinding(parseQuery),
+			),
+		),
+		cel.Function("format_query",
+			cel.MemberOverload(
+				"map_format_query",
+				[]*cel.Type{mapStringDyn},
+				cel.StringType,
+				cel.UnaryBinding(formatQuery),
 			),
 		),
 	}
 }
 
-func (l httpLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator: "head_string",
-				Unary:    l.doHead,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "get_string",
-				Unary:    l.doGet,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "get_request_string",
-				Unary:    newGetRequest,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "post_string_string_bytes",
-				Function: l.doPost,
-			},
-			&functions.Overload{
-				Operator: "post_string_string_string",
-				Function: l.doPost,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "post_request_string_string_bytes",
-				Function: newPostRequest,
-			},
-			&functions.Overload{
-				Operator: "post_request_string_string_string",
-				Function: newPostRequest,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "request_string_string",
-				Binary:   newRequest,
-			},
-			&functions.Overload{
-				Operator: "request_string_string_bytes",
-				Function: newRequestBody,
-			},
-			&functions.Overload{
-				Operator: "request_string_string_string",
-				Function: newRequestBody,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "map_basic_authentication_string_string",
-				Function: l.basicAuthentication,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "map_do_request",
-				Unary:    l.doRequest,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_parse_url",
-				Unary:    parseURL,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "map_format_url",
-				Unary:    formatURL,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_parse_query",
-				Unary:    parseQuery,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "map_format_query",
-				Unary:    formatQuery,
-			},
-		),
-	}
-}
+func (httpLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func (l httpLib) doHead(arg ref.Val) ref.Val {
 	url, ok := arg.(types.String)

--- a/lib/json.go
+++ b/lib/json.go
@@ -25,11 +25,8 @@ import (
 
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/interpreter/functions"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // JSON returns a cel.EnvOption to configure extended functions for JSON
@@ -79,7 +76,7 @@ import (
 //
 //	'{"a":1}{"b":2}'.decode_json_stream()   // return [{"a":1}, {"b":2}]
 //	b'{"a":1}{"b":2}'.decode_json_stream()  // return [{"a":1}, {"b":2}]
-func JSON(adapter ref.TypeAdapter) cel.EnvOption {
+func JSON(adapter types.Adapter) cel.EnvOption {
 	if adapter == nil {
 		adapter = types.DefaultTypeAdapter
 	}
@@ -87,122 +84,83 @@ func JSON(adapter ref.TypeAdapter) cel.EnvOption {
 }
 
 type jsonLib struct {
-	adapter ref.TypeAdapter
+	adapter types.Adapter
 }
 
-func (jsonLib) CompileOptions() []cel.EnvOption {
+func (l jsonLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Declarations(
-			decls.NewFunction("encode_json",
-				decls.NewOverload(
-					"encode_json_dyn",
-					[]*expr.Type{decls.Dyn},
-					decls.String,
-				),
-				decls.NewInstanceOverload(
-					"dyn_encode_json",
-					[]*expr.Type{decls.Dyn},
-					decls.String,
-				),
+		cel.Function("encode_json",
+			cel.MemberOverload(
+				"dyn_encode_json",
+				[]*cel.Type{cel.DynType},
+				cel.StringType,
+				cel.UnaryBinding(encodeJSON),
 			),
-			decls.NewFunction("decode_json",
-				decls.NewOverload(
-					"decode_json_string",
-					[]*expr.Type{decls.String},
-					decls.Dyn,
-				),
-				decls.NewInstanceOverload(
-					"string_decode_json",
-					[]*expr.Type{decls.String},
-					decls.Dyn,
-				),
-				decls.NewOverload(
-					"decode_json_bytes",
-					[]*expr.Type{decls.Bytes},
-					decls.Dyn,
-				),
-				decls.NewInstanceOverload(
-					"bytes_decode_json",
-					[]*expr.Type{decls.Bytes},
-					decls.Dyn,
-				),
+			cel.Overload(
+				"encode_json_dyn",
+				[]*cel.Type{cel.DynType},
+				cel.StringType,
+				cel.UnaryBinding(encodeJSON),
 			),
-			decls.NewFunction("decode_json_stream",
-				decls.NewOverload(
-					"decode_json_stream_string",
-					[]*expr.Type{decls.String},
-					decls.NewListType(decls.Dyn),
-				),
-				decls.NewInstanceOverload(
-					"string_decode_json_stream",
-					[]*expr.Type{decls.String},
-					decls.NewListType(decls.Dyn),
-				),
-				decls.NewOverload(
-					"decode_json_stream_bytes",
-					[]*expr.Type{decls.Bytes},
-					decls.NewListType(decls.Dyn),
-				),
-				decls.NewInstanceOverload(
-					"bytes_decode_json_stream",
-					[]*expr.Type{decls.Bytes},
-					decls.NewListType(decls.Dyn),
-				),
+		),
+
+		cel.Function("decode_json",
+			cel.MemberOverload(
+				"string_decode_json",
+				[]*cel.Type{cel.StringType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeJSON),
+			),
+			cel.Overload(
+				"decode_json_string",
+				[]*cel.Type{cel.StringType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeJSON),
+			),
+			cel.MemberOverload(
+				"bytes_decode_json",
+				[]*cel.Type{cel.BytesType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeJSON),
+			),
+			cel.Overload(
+				"decode_json_bytes",
+				[]*cel.Type{cel.BytesType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeJSON),
+			),
+		),
+
+		cel.Function("decode_json_stream",
+			cel.MemberOverload(
+				"string_decode_json_stream",
+				[]*cel.Type{cel.StringType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeJSONStream),
+			),
+			cel.Overload(
+				"decode_json_stream_string",
+				[]*cel.Type{cel.StringType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeJSONStream),
+			),
+			cel.MemberOverload(
+				"bytes_decode_json_stream",
+				[]*cel.Type{cel.BytesType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeJSONStream),
+			),
+			cel.Overload(
+				"decode_json_stream_bytes",
+				[]*cel.Type{cel.BytesType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeJSONStream),
 			),
 		),
 	}
 }
 
-func (l jsonLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator: "encode_json_dyn",
-				Unary:    encodeJSON,
-			},
-			&functions.Overload{
-				Operator: "dyn_encode_json",
-				Unary:    encodeJSON,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "decode_json_string",
-				Unary:    l.decodeJSON,
-			},
-			&functions.Overload{
-				Operator: "decode_json_bytes",
-				Unary:    l.decodeJSON,
-			},
-			&functions.Overload{
-				Operator: "string_decode_json",
-				Unary:    l.decodeJSON,
-			},
-			&functions.Overload{
-				Operator: "bytes_decode_json",
-				Unary:    l.decodeJSON,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "decode_json_stream_string",
-				Unary:    l.decodeJSONStream,
-			},
-			&functions.Overload{
-				Operator: "decode_json_stream_bytes",
-				Unary:    l.decodeJSONStream,
-			},
-			&functions.Overload{
-				Operator: "string_decode_json_stream",
-				Unary:    l.decodeJSONStream,
-			},
-			&functions.Overload{
-				Operator: "bytes_decode_json_stream",
-				Unary:    l.decodeJSONStream,
-			},
-		),
-	}
-}
+func (jsonLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func encodeJSON(val ref.Val) ref.Val {
 	var v interface{}

--- a/lib/limit.go
+++ b/lib/limit.go
@@ -26,13 +26,10 @@ import (
 	"time"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
-	"github.com/google/cel-go/interpreter/functions"
 	"golang.org/x/time/rate"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // Limit returns a cel.EnvOption to configure extended functions for interpreting
@@ -93,41 +90,26 @@ type limitLib struct {
 	policies map[string]LimitPolicy
 }
 
-func (limitLib) CompileOptions() []cel.EnvOption {
+func (l limitLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Declarations(
-			decls.NewFunction("rate_limit",
-				decls.NewOverload(
-					"map_dyn_rate_limit_string_duration",
-					[]*expr.Type{decls.NewMapType(decls.String, decls.Dyn), decls.String, decls.Duration},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
+		cel.Function("rate_limit",
+			cel.Overload(
+				"map_dyn_rate_limit_string_duration",
+				[]*cel.Type{mapStringDyn, cel.StringType, cel.DurationType},
+				mapStringDyn,
+				cel.FunctionBinding(l.translatePolicy),
 			),
-			decls.NewFunction("rate_limit",
-				decls.NewOverload(
-					"map_dyn_rate_limit_string_bool_bool_duration_int",
-					[]*expr.Type{decls.NewMapType(decls.String, decls.Dyn), decls.String, decls.Bool, decls.Bool, decls.Duration, decls.Int},
-					decls.NewMapType(decls.String, decls.Dyn),
-				),
+			cel.Overload(
+				"map_dyn_rate_limit_string_bool_bool_duration_int",
+				[]*cel.Type{mapStringDyn, cel.StringType, cel.BoolType, cel.BoolType, cel.DurationType, cel.IntType},
+				mapStringDyn,
+				cel.FunctionBinding(translatePolicy),
 			),
 		),
 	}
 }
 
-func (l limitLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator: "map_dyn_rate_limit_string_duration",
-				Function: l.translatePolicy,
-			},
-			&functions.Overload{
-				Operator: "map_dyn_rate_limit_string_bool_bool_duration_int",
-				Function: translatePolicy,
-			},
-		),
-	}
-}
+func (limitLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func (l limitLib) translatePolicy(args ...ref.Val) ref.Val {
 	if len(args) != 3 {

--- a/lib/mime.go
+++ b/lib/mime.go
@@ -27,11 +27,8 @@ import (
 	"os"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/interpreter/functions"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // MIME returns a cel.EnvOption to configure extended functions for reading files.
@@ -62,30 +59,20 @@ type mimeLib struct {
 	transforms map[string]interface{}
 }
 
-func (mimeLib) CompileOptions() []cel.EnvOption {
+func (l mimeLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Declarations(
-			decls.NewFunction("mime",
-				decls.NewInstanceOverload(
-					"bytes_mime_string",
-					[]*expr.Type{decls.Bytes, decls.String},
-					decls.Dyn,
-				),
+		cel.Function("mime",
+			cel.MemberOverload(
+				"bytes_mime_string",
+				[]*cel.Type{cel.BytesType, cel.StringType},
+				cel.DynType,
+				cel.BinaryBinding(l.transformMIME),
 			),
 		),
 	}
 }
 
-func (l mimeLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator: "bytes_mime_string",
-				Binary:   l.transformMIME,
-			},
-		),
-	}
-}
+func (mimeLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func (l mimeLib) transformMIME(arg0, arg1 ref.Val) ref.Val {
 	input, ok := arg0.(types.Bytes)

--- a/lib/regexp.go
+++ b/lib/regexp.go
@@ -21,11 +21,8 @@ import (
 	"regexp"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/interpreter/functions"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // Regexp returns a cel.EnvOption to configure extended functions for
@@ -122,98 +119,58 @@ type regexpLib map[string]*regexp.Regexp
 
 func (l regexpLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Declarations(
-			decls.NewFunction("re_match",
-				decls.NewInstanceOverload(
-					"typeV_re_match_string",
-					[]*expr.Type{decls.Dyn, decls.String},
-					decls.Bool,
-				),
+		cel.Function("re_match",
+			cel.MemberOverload(
+				"typeV_re_match_string",
+				[]*cel.Type{cel.DynType, cel.StringType},
+				cel.BoolType,
+				cel.BinaryBinding(l.match),
 			),
-			decls.NewFunction("re_find",
-				decls.NewParameterizedInstanceOverload(
-					"typeV_re_find_string",
-					[]*expr.Type{typeV, decls.String},
-					typeV,
-					[]string{"V"},
-				),
+		),
+		cel.Function("re_find",
+			cel.MemberOverload(
+				"typeV_re_find_string",
+				[]*cel.Type{typeV, cel.StringType},
+				typeV,
+				cel.BinaryBinding(l.find),
 			),
-			decls.NewFunction("re_find_all",
-				decls.NewParameterizedInstanceOverload(
-					"typeV_re_find_all_string",
-					[]*expr.Type{typeV, decls.String},
-					decls.NewListType(typeV),
-					[]string{"V"},
-				),
+		),
+		cel.Function("re_find_all",
+			cel.MemberOverload(
+				"typeV_re_find_all_string",
+				[]*cel.Type{typeV, cel.StringType},
+				listV,
+				cel.BinaryBinding(l.findAll),
 			),
-			decls.NewFunction("re_find_submatch",
-				decls.NewParameterizedInstanceOverload(
-					"typeV_re_find_submatch_string",
-					[]*expr.Type{typeV, decls.String},
-					decls.NewListType(typeV),
-					[]string{"V"},
-				),
+		),
+		cel.Function("re_find_submatch",
+			cel.MemberOverload(
+				"typeV_re_find_submatch_string",
+				[]*cel.Type{typeV, cel.StringType},
+				typeV,
+				cel.BinaryBinding(l.findSubmatch),
 			),
-			decls.NewFunction("re_find_all_submatch",
-				decls.NewParameterizedInstanceOverload(
-					"typeV_re_find_all_submatch_string",
-					[]*expr.Type{typeV, decls.String},
-					decls.NewListType(decls.NewListType(typeV)),
-					[]string{"V"},
-				),
+		),
+		cel.Function("re_find_all_submatch",
+			cel.MemberOverload(
+				"typeV_re_find_all_submatch_string",
+				[]*cel.Type{typeV, cel.StringType},
+				listV,
+				cel.BinaryBinding(l.findAllSubmatch),
 			),
-			decls.NewFunction("re_replace_all",
-				decls.NewParameterizedInstanceOverload(
-					"typeV_re_replace_all_string_dyn",
-					[]*expr.Type{typeV, decls.String, typeV},
-					typeV,
-					[]string{"V"},
-				),
+		),
+		cel.Function("re_replace_all",
+			cel.MemberOverload(
+				"typeV_re_replace_all_string_dyn",
+				[]*cel.Type{typeV, cel.StringType, typeV},
+				typeV,
+				cel.FunctionBinding(l.replaceAll),
 			),
 		),
 	}
 }
 
-func (l regexpLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator: "typeV_re_match_string",
-				Binary:   l.match,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "typeV_re_find_string",
-				Binary:   l.find,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "typeV_re_find_all_string",
-				Binary:   l.findAll,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "typeV_re_find_submatch_string",
-				Binary:   l.findSubmatch,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "typeV_re_find_all_submatch_string",
-				Binary:   l.findAllSubmatch,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "typeV_re_replace_all_string_dyn",
-				Function: l.replaceAll,
-			},
-		),
-	}
-}
+func (regexpLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func (l regexpLib) match(arg1, arg2 ref.Val) ref.Val {
 	patName, ok := arg2.(types.String)

--- a/lib/send.go
+++ b/lib/send.go
@@ -21,11 +21,8 @@ import (
 	"fmt"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/interpreter/functions"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // Send returns a cel.EnvOption to configure extended functions for sending
@@ -60,78 +57,52 @@ func Send(ch map[string]chan interface{}) cel.EnvOption {
 
 type sendLib map[string]chan interface{}
 
-func (sendLib) CompileOptions() []cel.EnvOption {
+func (ch sendLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Declarations(
-			decls.NewFunction("send_refval_to",
-				decls.NewInstanceOverload(
-					"dyn_send_refval_string",
-					[]*expr.Type{decls.Dyn, decls.String},
-					decls.Dyn,
-				),
-				decls.NewOverload(
-					"send_dyn_refval_string",
-					[]*expr.Type{decls.Dyn, decls.String},
-					decls.Dyn,
-				),
+		cel.Function("send_refval_to",
+			cel.MemberOverload(
+				"dyn_send_refval_string",
+				[]*cel.Type{cel.DynType, cel.StringType},
+				cel.DynType,
+				cel.BinaryBinding(ch.sendRefVal),
+				cel.OverloadIsNonStrict(),
 			),
-			decls.NewFunction("send_to",
-				decls.NewInstanceOverload(
-					"dyn_send_string",
-					[]*expr.Type{decls.Dyn, decls.String},
-					decls.Dyn,
-				),
-				decls.NewOverload(
-					"send_dyn_string",
-					[]*expr.Type{decls.Dyn, decls.String},
-					decls.Dyn,
-				),
+			cel.Overload(
+				"send_dyn_refval_string",
+				[]*cel.Type{cel.DynType, cel.StringType},
+				cel.DynType,
+				cel.BinaryBinding(ch.sendRefVal),
+				cel.OverloadIsNonStrict(),
 			),
-			decls.NewFunction("close",
-				decls.NewInstanceOverload(
-					"dyn_close_string",
-					[]*expr.Type{decls.Dyn, decls.String},
-					decls.Bool,
-				),
+		),
+		cel.Function("send_to",
+			cel.MemberOverload(
+				"dyn_send_string",
+				[]*cel.Type{cel.DynType, cel.StringType},
+				cel.DynType,
+				cel.BinaryBinding(ch.send),
+				cel.OverloadIsNonStrict(),
+			),
+			cel.Overload(
+				"send_dyn_string",
+				[]*cel.Type{cel.DynType, cel.StringType},
+				cel.DynType,
+				cel.BinaryBinding(ch.send),
+				cel.OverloadIsNonStrict(),
+			),
+		),
+		cel.Function("close",
+			cel.MemberOverload(
+				"dyn_close_string",
+				[]*cel.Type{cel.DynType, cel.StringType},
+				cel.BoolType,
+				cel.BinaryBinding(ch.close),
 			),
 		),
 	}
 }
 
-func (ch sendLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator:  "dyn_send_refval_string",
-				Binary:    ch.sendRefVal,
-				NonStrict: true,
-			},
-			&functions.Overload{
-				Operator:  "send_dyn_refval_string",
-				Binary:    ch.sendRefVal,
-				NonStrict: true,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator:  "dyn_send_string",
-				Binary:    ch.send,
-				NonStrict: true,
-			},
-			&functions.Overload{
-				Operator:  "send_dyn_string",
-				Binary:    ch.send,
-				NonStrict: true,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "dyn_close_string",
-				Binary:   ch.close,
-			},
-		),
-	}
-}
+func (sendLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func (ch sendLib) close(_, arg ref.Val) ref.Val {
 	name, ok := arg.(types.String)

--- a/lib/strings.go
+++ b/lib/strings.go
@@ -22,11 +22,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/interpreter/functions"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // Strings returns a cel.EnvOption to configure extended functions for
@@ -95,495 +92,266 @@ func Strings() cel.EnvOption {
 
 type stringLib struct{}
 
-func (stringLib) CompileOptions() []cel.EnvOption {
+func (l stringLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Declarations(
-			decls.NewFunction("compare",
-				decls.NewInstanceOverload(
-					"string_compare_string_int",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Int,
-				),
+		cel.Function("compare",
+			cel.MemberOverload(
+				"string_compare_string_int",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.IntType,
+				cel.BinaryBinding(l.compare),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("contains_substr", // required to disambiguate from regexp.contains.
-				decls.NewInstanceOverload(
-					"string_contains_substr_string_bool",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Bool,
-				),
+		cel.Function("contains_substr" /* required to disambiguate from regexp.contains.*/, cel.MemberOverload(
+			"string_contains_substr_string_bool",
+			[]*cel.Type{cel.StringType, cel.StringType},
+			cel.BoolType,
+			cel.BinaryBinding(l.contains),
+		)),
+		cel.Function("contains_any",
+			cel.MemberOverload(
+				"string_contains_any_string_bool",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.BoolType,
+				cel.BinaryBinding(l.containsAny),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("contains_any",
-				decls.NewInstanceOverload(
-					"string_contains_any_string_bool",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Bool,
-				),
+		cel.Function("count",
+			cel.MemberOverload(
+				"string_count_string_int",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.IntType,
+				cel.BinaryBinding(l.count),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("count",
-				decls.NewInstanceOverload(
-					"string_count_string_int",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Int,
-				),
+		cel.Function("equal_fold",
+			cel.MemberOverload(
+				"string_equal_fold_string_bool",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.BoolType,
+				cel.BinaryBinding(l.equalFold),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("equal_fold",
-				decls.NewInstanceOverload(
-					"string_equal_fold_string_bool",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Bool,
-				),
+		cel.Function("fields",
+			cel.MemberOverload(
+				"string_fields_list_string",
+				[]*cel.Type{cel.StringType},
+				listString,
+				cel.UnaryBinding(l.fields),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("fields",
-				decls.NewInstanceOverload(
-					"string_fields_list_string",
-					[]*expr.Type{decls.String},
-					listString,
-				),
+		cel.Function("has_prefix",
+			cel.MemberOverload(
+				"string_has_prefix_string_bool",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.BoolType,
+				cel.BinaryBinding(l.hasPrefix),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("has_prefix",
-				decls.NewInstanceOverload(
-					"string_has_prefix_string_bool",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Bool,
-				),
+		cel.Function("has_suffix",
+			cel.MemberOverload(
+				"string_has_suffix_string_bool",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.BoolType,
+				cel.BinaryBinding(l.hasSuffix),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("has_suffix",
-				decls.NewInstanceOverload(
-					"string_has_suffix_string_bool",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Bool,
-				),
+		cel.Function("index",
+			cel.MemberOverload(
+				"string_index_string_int",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.IntType,
+				cel.BinaryBinding(l.index),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("index",
-				decls.NewInstanceOverload(
-					"string_index_string_int",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Int,
-				),
+		cel.Function("index_any",
+			cel.MemberOverload(
+				"string_index_any_string_int",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.IntType,
+				cel.BinaryBinding(l.indexAny),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("index_any",
-				decls.NewInstanceOverload(
-					"string_index_any_string_int",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Int,
-				),
+		cel.Function("join",
+			cel.MemberOverload(
+				"list_string_join_string_string",
+				[]*cel.Type{listString, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(l.join),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("join",
-				decls.NewInstanceOverload(
-					"list_string_join_string_string",
-					[]*expr.Type{listString, decls.String},
-					decls.String,
-				),
+		cel.Function("last_index",
+			cel.MemberOverload(
+				"string_last_index_string_int",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.IntType,
+				cel.BinaryBinding(l.lastIndex),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("last_index",
-				decls.NewInstanceOverload(
-					"string_last_index_string_int",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Int,
-				),
+		cel.Function("last_index_any",
+			cel.MemberOverload(
+				"string_last_index_any_string_int",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.IntType,
+				cel.BinaryBinding(l.lastIndexAny),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("last_index_any",
-				decls.NewInstanceOverload(
-					"string_last_index_any_string_int",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Int,
-				),
+		cel.Function("repeat",
+			cel.MemberOverload(
+				"string_repeat_int_string",
+				[]*cel.Type{cel.StringType, cel.IntType},
+				cel.StringType,
+				cel.BinaryBinding(l.repeat),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("repeat",
-				decls.NewInstanceOverload(
-					"string_repeat_int_string",
-					[]*expr.Type{decls.String, decls.Int},
-					decls.String,
-				),
+		cel.Function("replace",
+			cel.MemberOverload(
+				"string_replace_string_string_int_string",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.StringType, cel.IntType},
+				cel.StringType,
+				cel.FunctionBinding(l.replace),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("replace",
-				decls.NewInstanceOverload(
-					"string_replace_string_string_int_string",
-					[]*expr.Type{decls.String, decls.String, decls.String, decls.Int},
-					decls.String,
-				),
+		cel.Function("replace_all",
+			cel.MemberOverload(
+				"string_replace_all_string_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.StringType},
+				cel.StringType,
+				cel.FunctionBinding(l.replaceAll),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("replace_all",
-				decls.NewInstanceOverload(
-					"string_replace_all_string_string_string",
-					[]*expr.Type{decls.String, decls.String, decls.String},
-					decls.String,
-				),
+		cel.Function("split",
+			cel.MemberOverload(
+				"string_split_string_list_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				listString,
+				cel.BinaryBinding(l.split),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("split",
-				decls.NewInstanceOverload(
-					"string_split_string_list_string",
-					[]*expr.Type{decls.String, decls.String},
-					listString,
-				),
+		cel.Function("split_after",
+			cel.MemberOverload(
+				"string_split_after_string_list_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				listString,
+				cel.BinaryBinding(l.splitAfter),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("split_after",
-				decls.NewInstanceOverload(
-					"string_split_after_string_list_string",
-					[]*expr.Type{decls.String, decls.String},
-					listString,
-				),
+		cel.Function("split_after_n",
+			cel.MemberOverload(
+				"string_split_after_n_string_int_list_string",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.IntType},
+				listString,
+				cel.FunctionBinding(l.splitAfterN),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("split_after_n",
-				decls.NewInstanceOverload(
-					"string_split_after_n_string_int_list_string",
-					[]*expr.Type{decls.String, decls.String, decls.Int},
-					listString,
-				),
+		cel.Function("split_n",
+			cel.MemberOverload(
+				"string_split_n_string_int_list_string",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.IntType},
+				listString,
+				cel.FunctionBinding(l.splitN),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("split_n",
-				decls.NewInstanceOverload(
-					"string_split_n_string_int_list_string",
-					[]*expr.Type{decls.String, decls.String, decls.Int},
-					listString,
-				),
+		cel.Function("substring",
+			cel.MemberOverload(
+				"string_substring_int_int_string",
+				[]*cel.Type{cel.StringType, cel.IntType, cel.IntType},
+				cel.StringType,
+				cel.FunctionBinding(l.substring),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("substring",
-				decls.NewInstanceOverload(
-					"string_substring_int_int_string",
-					[]*expr.Type{decls.String, decls.Int, decls.Int},
-					decls.String,
-				),
+		cel.Function("to_lower",
+			cel.MemberOverload(
+				"string_to_lower_string",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(l.toLower),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("to_lower",
-				decls.NewInstanceOverload(
-					"string_to_lower_string",
-					[]*expr.Type{decls.String},
-					decls.String,
-				),
+		cel.Function("to_title",
+			cel.MemberOverload(
+				"string_to_title_string",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(l.toTitle),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("to_title",
-				decls.NewInstanceOverload(
-					"string_to_title_string",
-					[]*expr.Type{decls.String},
-					decls.String,
-				),
+		cel.Function("to_upper",
+			cel.MemberOverload(
+				"string_to_upper_string",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(l.toUpper),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("to_upper",
-				decls.NewInstanceOverload(
-					"string_to_upper_string",
-					[]*expr.Type{decls.String},
-					decls.String,
-				),
+		cel.Function("to_valid_utf8",
+			cel.MemberOverload(
+				"bytes_to_valid_utf8_string_string",
+				[]*cel.Type{cel.BytesType, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(l.toValidUTF8),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("to_valid_utf8",
-				decls.NewInstanceOverload(
-					"bytes_to_valid_utf8_string_string",
-					[]*expr.Type{decls.Bytes, decls.String},
-					decls.String,
-				),
+		cel.Function("trim",
+			cel.MemberOverload(
+				"string_trim_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(l.trim),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("trim",
-				decls.NewInstanceOverload(
-					"string_trim_string_string",
-					[]*expr.Type{decls.String, decls.String},
-					decls.String,
-				),
+		cel.Function("trim_left",
+			cel.MemberOverload(
+				"string_trim_left_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(l.trimLeft),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("trim_left",
-				decls.NewInstanceOverload(
-					"string_trim_left_string_string",
-					[]*expr.Type{decls.String, decls.String},
-					decls.String,
-				),
+		cel.Function("trim_prefix",
+			cel.MemberOverload(
+				"string_trim_prefix_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(l.trimPrefix),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("trim_prefix",
-				decls.NewInstanceOverload(
-					"string_trim_prefix_string_string",
-					[]*expr.Type{decls.String, decls.String},
-					decls.String,
-				),
+		cel.Function("trim_right",
+			cel.MemberOverload(
+				"string_trim_right_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(l.trimRight),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("trim_right",
-				decls.NewInstanceOverload(
-					"string_trim_right_string_string",
-					[]*expr.Type{decls.String, decls.String},
-					decls.String,
-				),
+		cel.Function("trim_space",
+			cel.MemberOverload(
+				"string_trim_space_string",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(l.trimSpace),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("trim_space",
-				decls.NewInstanceOverload(
-					"string_trim_space_string",
-					[]*expr.Type{decls.String},
-					decls.String,
-				),
+		cel.Function("trim_suffix",
+			cel.MemberOverload(
+				"string_trim_suffix_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(l.trimSuffix),
 			),
 		),
-		cel.Declarations(
-			decls.NewFunction("trim_suffix",
-				decls.NewInstanceOverload(
-					"string_trim_suffix_string_string",
-					[]*expr.Type{decls.String, decls.String},
-					decls.String,
-				),
-			),
-		),
-		cel.Declarations(
-			decls.NewFunction("valid_utf8",
-				decls.NewInstanceOverload(
-					"bytes_valid_utf8_bool",
-					[]*expr.Type{decls.Bytes},
-					decls.Bool,
-				),
+		cel.Function("valid_utf8",
+			cel.MemberOverload(
+				"bytes_valid_utf8_bool",
+				[]*cel.Type{cel.BytesType},
+				cel.BoolType,
+				cel.UnaryBinding(l.validString),
 			),
 		),
 	}
 }
 
-func (l stringLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_compare_string_int",
-				Binary:   l.compare,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_contains_substr_string_bool",
-				Binary:   l.contains,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_contains_any_string_bool",
-				Binary:   l.containsAny,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_count_string_int",
-				Binary:   l.count,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_equal_fold_string_bool",
-				Binary:   l.equalFold,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_fields_list_string",
-				Unary:    l.fields,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_has_prefix_string_bool",
-				Binary:   l.hasPrefix,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_has_suffix_string_bool",
-				Binary:   l.hasSuffix,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_index_string_int",
-				Binary:   l.index,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_index_any_string_int",
-				Binary:   l.indexAny,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "list_string_join_string_string",
-				Binary:   l.join,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_last_index_string_int",
-				Binary:   l.lastIndex,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_last_index_any_string_int",
-				Binary:   l.lastIndexAny,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_repeat_int_string",
-				Binary:   l.repeat,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_replace_string_string_int_string",
-				Function: l.replace,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_replace_all_string_string_string",
-				Function: l.replaceAll,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_split_string_list_string",
-				Binary:   l.split,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_split_after_string_list_string",
-				Binary:   l.splitAfter,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_split_after_n_string_int_list_string",
-				Function: l.splitAfterN,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_split_n_string_int_list_string",
-				Function: l.splitN,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_substring_int_int_string",
-				Function: l.substring,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_to_lower_string",
-				Unary:    l.toLower,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_to_title_string",
-				Unary:    l.toTitle,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_to_upper_string",
-				Unary:    l.toUpper,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "bytes_to_valid_utf8_string_string",
-				Binary:   l.toValidUTF8,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_trim_string_string",
-				Binary:   l.trim,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_trim_left_string_string",
-				Binary:   l.trimLeft,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_trim_prefix_string_string",
-				Binary:   l.trimPrefix,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_trim_right_string_string",
-				Binary:   l.trimRight,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_trim_space_string",
-				Unary:    l.trimSpace,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "string_trim_suffix_string_string",
-				Binary:   l.trimSuffix,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "bytes_valid_utf8_bool",
-				Unary:    l.validString,
-			},
-		),
-	}
-}
+func (stringLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func (l stringLib) compare(arg0, arg1 ref.Val) ref.Val {
 	a, ok := arg0.(types.String)

--- a/lib/time.go
+++ b/lib/time.go
@@ -26,8 +26,6 @@ import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
-	"github.com/google/cel-go/interpreter/functions"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // Time returns a cel.EnvOption to configure extended functions for
@@ -116,31 +114,37 @@ func (timeLib) CompileOptions() []cel.EnvOption {
 		cel.Declarations(
 			decls.NewVar("now", decls.Dyn),
 			decls.NewVar("time_layout", decls.NewMapType(decls.String, decls.String)),
-			decls.NewFunction("now",
-				decls.NewOverload(
-					"now_void",
-					nil,
-					decls.Timestamp,
-				),
+		),
+		cel.Function("now",
+			cel.Overload(
+				"now_void",
+				nil,
+				cel.TimestampType,
+				cel.FunctionBinding(now),
 			),
-			decls.NewFunction("format",
-				decls.NewInstanceOverload(
-					"timestamp_format_string",
-					[]*expr.Type{decls.Timestamp, decls.String},
-					decls.String,
-				),
+		),
+		cel.Function("format",
+			cel.MemberOverload(
+				"timestamp_format_string",
+				[]*cel.Type{cel.TimestampType, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(formatTime),
 			),
-			decls.NewFunction("parse_time",
-				decls.NewInstanceOverload(
-					"string_parse_time_string",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Timestamp,
-				),
-				decls.NewInstanceOverload(
-					"string_parse_time_list_string",
-					[]*expr.Type{decls.String, decls.NewListType(decls.String)},
-					decls.Timestamp,
-				),
+		),
+		cel.Function("parse_time",
+			cel.MemberOverload(
+				"string_parse_time_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.TimestampType,
+				cel.BinaryBinding(parseTimeWithLayout),
+			),
+		),
+		cel.Function("parse_time",
+			cel.MemberOverload(
+				"string_parse_time_list_string",
+				[]*cel.Type{cel.StringType, listString},
+				cel.TimestampType,
+				cel.BinaryBinding(parseTimeWithLayouts),
 			),
 		),
 	}
@@ -170,24 +174,6 @@ func (timeLib) ProgramOptions() []cel.ProgramOption {
 				"HTTP":        http.TimeFormat,
 			},
 		}),
-		cel.Functions(
-			&functions.Overload{
-				Operator: "now_void",
-				Function: now,
-			},
-			&functions.Overload{
-				Operator: "timestamp_format_string",
-				Binary:   formatTime,
-			},
-			&functions.Overload{
-				Operator: "string_parse_time_string",
-				Binary:   parseTimeWithLayout,
-			},
-			&functions.Overload{
-				Operator: "string_parse_time_list_string",
-				Binary:   parseTimeWithLayouts,
-			},
-		),
 	}
 }
 

--- a/lib/try.go
+++ b/lib/try.go
@@ -21,11 +21,8 @@ import (
 	"fmt"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/interpreter/functions"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // Try returns a cel.EnvOption to configure extended functions for allowing
@@ -65,53 +62,35 @@ type tryLib struct{}
 
 func (tryLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Declarations(
-			decls.NewFunction("try",
-				decls.NewOverload(
-					"try_dyn",
-					[]*expr.Type{decls.Dyn},
-					decls.Dyn,
-				),
-				decls.NewOverload(
-					"try_dyn_string",
-					[]*expr.Type{decls.Dyn, decls.String},
-					decls.Dyn,
-				),
+		cel.Function("try",
+			cel.Overload(
+				"try_dyn",
+				[]*cel.Type{cel.DynType},
+				cel.DynType,
+				cel.UnaryBinding(try),
+				cel.OverloadIsNonStrict(),
 			),
-			decls.NewFunction("is_error",
-				decls.NewOverload(
-					"is_error_dyn",
-					[]*expr.Type{decls.Dyn},
-					decls.Bool,
-				),
+			cel.Overload(
+				"try_dyn_string",
+				[]*cel.Type{cel.DynType, cel.StringType},
+				cel.DynType,
+				cel.BinaryBinding(tryMessage),
+				cel.OverloadIsNonStrict(),
+			),
+		),
+		cel.Function("is_error",
+			cel.Overload(
+				"is_error_dyn",
+				[]*cel.Type{cel.DynType},
+				cel.BoolType,
+				cel.UnaryBinding(isError),
+				cel.OverloadIsNonStrict(),
 			),
 		),
 	}
 }
 
-func (tryLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator:  "try_dyn",
-				Unary:     try,
-				NonStrict: true,
-			},
-			&functions.Overload{
-				Operator:  "try_dyn_string",
-				Binary:    tryMessage,
-				NonStrict: true,
-			},
-		),
-		cel.Functions(
-			&functions.Overload{
-				Operator:  "is_error_dyn",
-				Unary:     isError,
-				NonStrict: true,
-			},
-		),
-	}
-}
+func (tryLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func try(arg ref.Val) ref.Val {
 	if types.IsError(arg) {

--- a/lib/types.go
+++ b/lib/types.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	structpb "github.com/golang/protobuf/ptypes/struct"
-	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -34,13 +34,14 @@ const OptionalTypesVersion = 1
 
 // Types used in overloads.
 var (
-	typeV        = decls.NewTypeParamType("V")
-	typeK        = decls.NewTypeParamType("K")
-	mapKV        = decls.NewMapType(typeK, typeV)
-	mapStringDyn = decls.NewMapType(decls.String, decls.Dyn)
-	listV        = decls.NewListType(typeV)
-	listK        = decls.NewListType(typeK)
-	listString   = decls.NewListType(decls.String)
+	typeV        = cel.TypeParamType("V")
+	typeK        = cel.TypeParamType("K")
+	mapKV        = cel.MapType(typeK, typeV)
+	mapStringDyn = cel.MapType(cel.StringType, cel.DynType)
+	listV        = cel.ListType(typeV)
+	listK        = cel.ListType(typeK)
+	listDyn      = cel.ListType(cel.DynType)
+	listString   = cel.ListType(cel.StringType)
 )
 
 // Types used for conversion to native.

--- a/lib/xml.go
+++ b/lib/xml.go
@@ -23,11 +23,8 @@ import (
 	"strings"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/interpreter/functions"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
 	"github.com/elastic/mito/lib/xml"
 )
@@ -61,7 +58,7 @@ import (
 //	b"<?xml vers... ...>".decode_xml()   // return { ... }
 //	"<?xml vers... ...>".decode_xml("xsd")   // return { ... }
 //	b"<?xml vers... ...>".decode_xml("xsd")   // return { ... }
-func XML(adapter ref.TypeAdapter, xsd map[string]string) (cel.EnvOption, error) {
+func XML(adapter types.Adapter, xsd map[string]string) (cel.EnvOption, error) {
 	if adapter == nil {
 		adapter = types.DefaultTypeAdapter
 	}
@@ -77,98 +74,70 @@ func XML(adapter ref.TypeAdapter, xsd map[string]string) (cel.EnvOption, error) 
 }
 
 type xmlLib struct {
-	adapter ref.TypeAdapter
+	adapter types.Adapter
 
 	xsdDetails map[string]map[string]xml.Detail
 }
 
-func (xmlLib) CompileOptions() []cel.EnvOption {
+func (l xmlLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Declarations(
-			decls.NewFunction("decode_xml",
-				decls.NewOverload(
-					"decode_xml_string",
-					[]*expr.Type{decls.String},
-					decls.Dyn,
-				),
-				decls.NewInstanceOverload(
-					"string_decode_xml",
-					[]*expr.Type{decls.String},
-					decls.Dyn,
-				),
-				decls.NewOverload(
-					"decode_xml_bytes",
-					[]*expr.Type{decls.Bytes},
-					decls.Dyn,
-				),
-				decls.NewInstanceOverload(
-					"bytes_decode_xml",
-					[]*expr.Type{decls.Bytes},
-					decls.Dyn,
-				),
-				decls.NewOverload(
-					"decode_xml_string_string",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Dyn,
-				),
-				decls.NewInstanceOverload(
-					"string_decode_xml_string",
-					[]*expr.Type{decls.String, decls.String},
-					decls.Dyn,
-				),
-				decls.NewOverload(
-					"decode_xml_bytes_string",
-					[]*expr.Type{decls.Bytes, decls.String},
-					decls.Dyn,
-				),
-				decls.NewInstanceOverload(
-					"bytes_decode_xml_string",
-					[]*expr.Type{decls.Bytes, decls.String},
-					decls.Dyn,
-				),
+		cel.Function("decode_xml",
+			// Without type information.
+			cel.MemberOverload(
+				"string_decode_xml",
+				[]*cel.Type{cel.StringType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeXML),
+			),
+			cel.Overload(
+				"decode_xml_string",
+				[]*cel.Type{cel.StringType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeXML),
+			),
+			cel.MemberOverload(
+				"bytes_decode_xml",
+				[]*cel.Type{cel.BytesType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeXML),
+			),
+			cel.Overload(
+				"decode_xml_bytes",
+				[]*cel.Type{cel.BytesType},
+				cel.DynType,
+				cel.UnaryBinding(l.decodeXML),
+			),
+
+			// With type information.
+			cel.MemberOverload(
+				"string_decode_xml_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.DynType,
+				cel.BinaryBinding(l.decodeXMLWithXSD),
+			),
+			cel.Overload(
+				"decode_xml_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.DynType,
+				cel.BinaryBinding(l.decodeXMLWithXSD),
+			),
+			cel.MemberOverload(
+				"bytes_decode_xml_string",
+				[]*cel.Type{cel.BytesType, cel.StringType},
+				cel.DynType,
+				cel.BinaryBinding(l.decodeXMLWithXSD),
+			),
+			cel.Overload(
+				"decode_xml_bytes_string",
+				[]*cel.Type{cel.BytesType, cel.StringType},
+				cel.DynType,
+				cel.BinaryBinding(l.decodeXMLWithXSD),
 			),
 		),
 	}
 }
 
-func (l xmlLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		cel.Functions(
-			&functions.Overload{
-				Operator: "decode_xml_string",
-				Unary:    l.decodeXML,
-			},
-			&functions.Overload{
-				Operator: "decode_xml_bytes",
-				Unary:    l.decodeXML,
-			},
-			&functions.Overload{
-				Operator: "string_decode_xml",
-				Unary:    l.decodeXML,
-			},
-			&functions.Overload{
-				Operator: "bytes_decode_xml",
-				Unary:    l.decodeXML,
-			},
-			&functions.Overload{
-				Operator: "decode_xml_string_string",
-				Binary:   l.decodeXMLWithXSD,
-			},
-			&functions.Overload{
-				Operator: "decode_xml_bytes_string",
-				Binary:   l.decodeXMLWithXSD,
-			},
-			&functions.Overload{
-				Operator: "string_decode_xml_string",
-				Binary:   l.decodeXMLWithXSD,
-			},
-			&functions.Overload{
-				Operator: "bytes_decode_xml_string",
-				Binary:   l.decodeXMLWithXSD,
-			},
-		),
-	}
-}
+func (xmlLib) ProgramOptions() []cel.ProgramOption { return nil }
 
 func (l xmlLib) decodeXML(arg ref.Val) ref.Val {
 	return l.decodeXMLWithXSD(arg, types.String(""))

--- a/testdata/drop_type_checked.txt
+++ b/testdata/drop_type_checked.txt
@@ -1,0 +1,12 @@
+mito -data state.json -use all src.cel
+! stderr .
+cmp stdout want.txt
+
+-- state.json --
+{"a":{"b":1,"c":2},"d":{}}
+-- src.cel --
+state["a"].drop("c")
+-- want.txt --
+{
+	"b": 1
+}

--- a/testdata/drop_type_checked_hidden.txt
+++ b/testdata/drop_type_checked_hidden.txt
@@ -1,0 +1,12 @@
+mito -data state.json -use all src.cel
+! stderr .
+cmp stdout want.txt
+
+-- state.json --
+{"a":{"b":1,"c":2},"d":{}}
+-- src.cel --
+[state["a"]].drop("c")[0]
+-- want.txt --
+{
+	"b": 1
+}


### PR DESCRIPTION
This also fixes a compile-time type checking issue.

Unfortunately not mechanical, some colour and movement.

Please take a look.

Notes:

This change has been tested in all integrations that make use of CEL. This requires building a custom filebeat and then injecting that into a running stack. Details below...

```
$ cd $(go env GOPATH)/src/github.com/elastic/beats/x-pack/filebeat
$ go get github.com/elastic/mito@a9f5af2f7468ad8182a9ed73f0b220eabdb2505f
$ go mod tidy
$ PACKAGES=tar.gz PLATFORMS=linux/amd64 DEV=true SNAPSHOT=true mage -v package
```

Extract the zip in place and then...
```
$ docker cp build/distributions/filebeat-8.14.0-SNAPSHOT-linux-x86_64/filebeat <container-id>:/usr/share/elastic-agent/data/elastic-agent-<agent-sha-prefix>/components
$ cd $(go env GOPATH)/src/github.com/elastic/integrations
$ for ds in $(rg -l '^program: \|' | cut -d/ -f1,3 | sort | uniq); do (cd $(dirname $ds); echo $ds; elastic-package test system -d $(basename $ds)); done
```

Output (edited for verbosity)
```
carbon_black_cloud/alert_v7
Run system tests for the package
--- Test results for package: carbon_black_cloud - START ---
╭────────────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE            │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├────────────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ carbon_black_cloud │ alert_v7    │ system    │ cel       │ PASS   │ 33.553198415s │
╰────────────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: carbon_black_cloud - END   ---
Done
carbon_black_cloud/asset_vulnerability_summary
Run system tests for the package
--- Test results for package: carbon_black_cloud - START ---
╭────────────────────┬─────────────────────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE            │ DATA STREAM                 │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├────────────────────┼─────────────────────────────┼───────────┼───────────┼────────┼───────────────┤
│ carbon_black_cloud │ asset_vulnerability_summary │ system    │ httpjson  │ PASS   │ 31.933203073s │
│ carbon_black_cloud │ asset_vulnerability_summary │ system    │ cel       │ PASS   │ 29.809151676s │
╰────────────────────┴─────────────────────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: carbon_black_cloud - END   ---
Done
carbon_black_cloud/audit
Run system tests for the package
--- Test results for package: carbon_black_cloud - START ---
╭────────────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE            │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├────────────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ carbon_black_cloud │ audit       │ system    │ httpjson  │ PASS   │ 31.211807136s │
│ carbon_black_cloud │ audit       │ system    │ cel       │ PASS   │ 29.411471334s │
╰────────────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: carbon_black_cloud - END   ---
Done
crowdstrike/alert
Run system tests for the package
--- Test results for package: crowdstrike - START ---
╭─────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├─────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ crowdstrike │ alert       │ system    │ common    │ PASS   │ 37.069836019s │
╰─────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: crowdstrike - END   ---
Done
crowdstrike/host
Run system tests for the package
--- Test results for package: crowdstrike - START ---
╭─────────────┬─────────────┬───────────┬───────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │ TIME ELAPSED │
├─────────────┼─────────────┼───────────┼───────────┼────────┼──────────────┤
│ crowdstrike │ host        │ system    │ common    │ PASS   │ 34.73772644s │
╰─────────────┴─────────────┴───────────┴───────────┴────────┴──────────────╯
--- Test results for package: crowdstrike - END   ---
Done
eset_protect/detection
Run system tests for the package
--- Test results for package: eset_protect - START ---
╭──────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE      │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├──────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ eset_protect │ detection   │ system    │ default   │ PASS   │ 35.645378942s │
╰──────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: eset_protect - END   ---
Done
eset_protect/device_task
Run system tests for the package
--- Test results for package: eset_protect - START ---
╭──────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE      │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├──────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ eset_protect │ device_task │ system    │ default   │ PASS   │ 32.108562898s │
╰──────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: eset_protect - END   ---
Done
imperva_cloud_waf/event
Run system tests for the package
--- Test results for package: imperva_cloud_waf - START ---
╭───────────────────┬─────────────┬───────────┬───────────┬────────┬────────────────╮
│ PACKAGE           │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │   TIME ELAPSED │
├───────────────────┼─────────────┼───────────┼───────────┼────────┼────────────────┤
│ imperva_cloud_waf │ event       │ system    │ default   │ PASS   │ 2m7.672016889s │
╰───────────────────┴─────────────┴───────────┴───────────┴────────┴────────────────╯
--- Test results for package: imperva_cloud_waf - END   ---
Done
logstash/node_cel
Run system tests for the package
--- Test results for package: logstash - START ---
╭──────────┬─────────────┬───────────┬────────────────────────────────────┬────────┬───────────────╮
│ PACKAGE  │ DATA STREAM │ TEST TYPE │ TEST NAME                          │ RESULT │  TIME ELAPSED │
├──────────┼─────────────┼───────────┼────────────────────────────────────┼────────┼───────────────┤
│ logstash │ node_cel    │ system    │ default (variant: logstash_8.12.2) │ PASS   │ 41.683114929s │
╰──────────┴─────────────┴───────────┴────────────────────────────────────┴────────┴───────────────╯
--- Test results for package: logstash - END   ---
Done
logstash/pipeline
Run system tests for the package
--- Test results for package: logstash - START ---
╭──────────┬─────────────┬───────────┬────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE  │ DATA STREAM │ TEST TYPE │ TEST NAME                          │ RESULT │ TIME ELAPSED │
├──────────┼─────────────┼───────────┼────────────────────────────────────┼────────┼──────────────┤
│ logstash │ pipeline    │ system    │ default (variant: logstash_8.12.2) │ PASS   │ 43.13600559s │
╰──────────┴─────────────┴───────────┴────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: logstash - END   ---
Done
logstash/plugins
Run system tests for the package
--- Test results for package: logstash - START ---
╭──────────┬─────────────┬───────────┬────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE  │ DATA STREAM │ TEST TYPE │ TEST NAME                          │ RESULT │ TIME ELAPSED │
├──────────┼─────────────┼───────────┼────────────────────────────────────┼────────┼──────────────┤
│ logstash │ plugins     │ system    │ default (variant: logstash_8.12.2) │ PASS   │ 41.97027965s │
╰──────────┴─────────────┴───────────┴────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: logstash - END   ---
Done
menlo/dlp
Run system tests for the package
--- Test results for package: menlo - START ---
╭─────────┬─────────────┬───────────┬───────────┬────────┬─────────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │    TIME ELAPSED │
├─────────┼─────────────┼───────────┼───────────┼────────┼─────────────────┤
│ menlo   │ dlp         │ system    │ default   │ PASS   │ 1m35.505112221s │
╰─────────┴─────────────┴───────────┴───────────┴────────┴─────────────────╯
--- Test results for package: menlo - END   ---
Done
menlo/web
Run system tests for the package
--- Test results for package: menlo - START ---
╭─────────┬─────────────┬───────────┬───────────┬────────┬─────────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │    TIME ELAPSED │
├─────────┼─────────────┼───────────┼───────────┼────────┼─────────────────┤
│ menlo   │ web         │ system    │ default   │ PASS   │ 1m34.517868523s │
╰─────────┴─────────────┴───────────┴───────────┴────────┴─────────────────╯
--- Test results for package: menlo - END   ---
Done
mongodb_atlas/mongod_audit
Run system tests for the package
--- Test results for package: mongodb_atlas - START ---
╭───────────────┬──────────────┬───────────┬───────────┬────────┬─────────────────╮
│ PACKAGE       │ DATA STREAM  │ TEST TYPE │ TEST NAME │ RESULT │    TIME ELAPSED │
├───────────────┼──────────────┼───────────┼───────────┼────────┼─────────────────┤
│ mongodb_atlas │ mongod_audit │ system    │ default   │ PASS   │ 2m41.063346092s │
╰───────────────┴──────────────┴───────────┴───────────┴────────┴─────────────────╯
--- Test results for package: mongodb_atlas - END   ---
Done
mongodb_atlas/process
Run system tests for the package
--- Test results for package: mongodb_atlas - START ---
╭───────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE       │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├───────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ mongodb_atlas │ process     │ system    │ default   │ PASS   │ 33.576599878s │
╰───────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: mongodb_atlas - END   ---
Done
o365/audit
Run system tests for the package
--- Test results for package: o365 - START ---
╭─────────┬─────────────┬───────────┬───────────┬────────┬──────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │ TIME ELAPSED │
├─────────┼─────────────┼───────────┼───────────┼────────┼──────────────┤
│ o365    │ audit       │ system    │ cel       │ PASS   │ 36.75661057s │
╰─────────┴─────────────┴───────────┴───────────┴────────┴──────────────╯
--- Test results for package: o365 - END   ---
Done
prisma_cloud/alert
Run system tests for the package
--- Test results for package: prisma_cloud - START ---
╭──────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE      │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├──────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ prisma_cloud │ alert       │ system    │ input     │ PASS   │ 38.427710235s │
╰──────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: prisma_cloud - END   ---
Done
prisma_cloud/audit
Run system tests for the package
--- Test results for package: prisma_cloud - START ---
╭──────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE      │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├──────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ prisma_cloud │ audit       │ system    │ input     │ PASS   │ 34.344462304s │
╰──────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: prisma_cloud - END   ---
Done
prisma_cloud/host
Run system tests for the package
--- Test results for package: prisma_cloud - START ---
╭──────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE      │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├──────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ prisma_cloud │ host        │ system    │ udp       │ PASS   │ 40.607040055s │
│ prisma_cloud │ host        │ system    │ input     │ PASS   │ 37.586992525s │
│ prisma_cloud │ host        │ system    │ tcp       │ PASS   │ 41.719486861s │
╰──────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: prisma_cloud - END   ---
Done
prisma_cloud/host_profile
Run system tests for the package
--- Test results for package: prisma_cloud - START ---
╭──────────────┬──────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE      │ DATA STREAM  │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├──────────────┼──────────────┼───────────┼───────────┼────────┼───────────────┤
│ prisma_cloud │ host_profile │ system    │ udp       │ PASS   │ 41.283793356s │
│ prisma_cloud │ host_profile │ system    │ input     │ PASS   │ 36.070100403s │
│ prisma_cloud │ host_profile │ system    │ tcp       │ PASS   │  39.01639039s │
╰──────────────┴──────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: prisma_cloud - END   ---
Done
qualys_vmdr/asset_host_detection
Run system tests for the package
--- Test results for package: qualys_vmdr - START ---
╭─────────────┬──────────────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE     │ DATA STREAM          │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├─────────────┼──────────────────────┼───────────┼───────────┼────────┼───────────────┤
│ qualys_vmdr │ asset_host_detection │ system    │ default   │ PASS   │ 36.383668379s │
╰─────────────┴──────────────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: qualys_vmdr - END   ---
Done
qualys_vmdr/knowledge_base
Run system tests for the package
--- Test results for package: qualys_vmdr - START ---
╭─────────────┬────────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE     │ DATA STREAM    │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├─────────────┼────────────────┼───────────┼───────────┼────────┼───────────────┤
│ qualys_vmdr │ knowledge_base │ system    │ 1_invalid │ PASS   │ 35.115765253s │
│ qualys_vmdr │ knowledge_base │ system    │ 0_valid   │ PASS   │ 35.685290683s │
╰─────────────┴────────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: qualys_vmdr - END   ---
Done
symantec_edr_cloud/incident
Run system tests for the package
--- Test results for package: symantec_edr_cloud - START ---
╭────────────────────┬─────────────┬───────────┬───────────┬────────┬──────────────╮
│ PACKAGE            │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │ TIME ELAPSED │
├────────────────────┼─────────────┼───────────┼───────────┼────────┼──────────────┤
│ symantec_edr_cloud │ incident    │ system    │ default   │ PASS   │ 33.68674111s │
╰────────────────────┴─────────────┴───────────┴───────────┴────────┴──────────────╯
--- Test results for package: symantec_edr_cloud - END   ---
Done
ti_crowdstrike/intel
Run system tests for the package
--- Test results for package: ti_crowdstrike - START ---
╭────────────────┬─────────────┬───────────┬───────────┬────────┬──────────────╮
│ PACKAGE        │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │ TIME ELAPSED │
├────────────────┼─────────────┼───────────┼───────────┼────────┼──────────────┤
│ ti_crowdstrike │ intel       │ system    │ default   │ PASS   │ 37.82467619s │
╰────────────────┴─────────────┴───────────┴───────────┴────────┴──────────────╯
--- Test results for package: ti_crowdstrike - END   ---
Done
ti_crowdstrike/ioc
Run system tests for the package
--- Test results for package: ti_crowdstrike - START ---
╭────────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE        │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├────────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ ti_crowdstrike │ ioc         │ system    │ default   │ PASS   │ 36.728874623s │
╰────────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: ti_crowdstrike - END   ---
Done
ti_eclecticiq/threat
Run system tests for the package
--- Test results for package: ti_eclecticiq - START ---
╭───────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE       │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├───────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ ti_eclecticiq │ threat      │ system    │ default   │ PASS   │ 37.225964423s │
╰───────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: ti_eclecticiq - END   ---
Done
ti_opencti/indicator
Run system tests for the package
--- Test results for package: ti_opencti - START ---
╭────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE    │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ ti_opencti │ indicator   │ system    │ default   │ PASS   │ 36.778168017s │
╰────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: ti_opencti - END   ---
Done
ti_otx/pulses_subscribed
Run system tests for the package
--- Test results for package: ti_otx - START ---
╭─────────┬───────────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE │ DATA STREAM       │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├─────────┼───────────────────┼───────────┼───────────┼────────┼───────────────┤
│ ti_otx  │ pulses_subscribed │ system    │ default   │ PASS   │ 35.545566645s │
╰─────────┴───────────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: ti_otx - END   ---
Done
ti_threatconnect/indicator
Run system tests for the package
--- Test results for package: ti_threatconnect - START ---
╭──────────────────┬─────────────┬───────────┬───────────┬────────┬──────────────╮
│ PACKAGE          │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │ TIME ELAPSED │
├──────────────────┼─────────────┼───────────┼───────────┼────────┼──────────────┤
│ ti_threatconnect │ indicator   │ system    │ default   │ PASS   │ 36.34321235s │
╰──────────────────┴─────────────┴───────────┴───────────┴────────┴──────────────╯
--- Test results for package: ti_threatconnect - END   ---
Done
trellix_epo_cloud/device
Run system tests for the package
--- Test results for package: trellix_epo_cloud - START ---
╭───────────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE           │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├───────────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ trellix_epo_cloud │ device      │ system    │ default   │ PASS   │ 34.019966923s │
╰───────────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: trellix_epo_cloud - END   ---
Done
trellix_epo_cloud/event
Run system tests for the package
--- Test results for package: trellix_epo_cloud - START ---
╭───────────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE           │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├───────────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ trellix_epo_cloud │ event       │ system    │ default   │ PASS   │ 34.002782312s │
╰───────────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: trellix_epo_cloud - END   ---
Done
trellix_epo_cloud/group
Run system tests for the package
--- Test results for package: trellix_epo_cloud - START ---
╭───────────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE           │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├───────────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ trellix_epo_cloud │ group       │ system    │ default   │ PASS   │ 34.606420333s │
╰───────────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: trellix_epo_cloud - END   ---
Done
wiz/audit
Run system tests for the package
--- Test results for package: wiz - START ---
╭─────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├─────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ wiz     │ audit       │ system    │ default   │ PASS   │ 34.654596102s │
╰─────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: wiz - END   ---
Done
wiz/issue
Run system tests for the package
--- Test results for package: wiz - START ---
╭─────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├─────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ wiz     │ issue       │ system    │ default   │ PASS   │ 35.352024895s │
╰─────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: wiz - END   ---
Done
wiz/vulnerability
Run system tests for the package
--- Test results for package: wiz - START ---
╭─────────┬───────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE │ DATA STREAM   │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├─────────┼───────────────┼───────────┼───────────┼────────┼───────────────┤
│ wiz     │ vulnerability │ system    │ default   │ PASS   │ 35.345787921s │
╰─────────┴───────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: wiz - END   ---
Done
```

Sanity check
```
$ cd $(go env GOPATH)/src/github.com/elastic/beats/x-pack/filebeat
$ md5sum build/distributions/filebeat-8.14.0-SNAPSHOT-linux-x86_64/filebeat
6db9d666f528ffbf2087be42c74d9b23  …/github.com/elastic/beats/x-pack/filebeat/build/distributions/filebeat-8.14.0-SNAPSHOT-linux-x86_64/filebeat
$ docker exec 14e70ce88e33d7dc32c439194492813d7df5f2f755cd1a6046c8aee1f74e086e md5sum /usr/share/elastic-agent/data/elastic-agent-1eb18c/components/filebeat
6db9d666f528ffbf2087be42c74d9b23  /usr/share/elastic-agent/data/elastic-agent-1eb18c/components/filebeat
```