### PR TITLE
ci: run govulncheck before allowing progression

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: govulncheck
+      run: |
+        go run golang.org/x/vuln/cmd/govulncheck@latest
+
     - name: Test
       run: go test ./...
 


### PR DESCRIPTION
This adds social pressure to keep this up to date with published vulnerabilities.

Please take a look.