### PR TITLE
lib: fix rendering of errors containing percent symbols

### DIFF
--- a/lib/errors.go
+++ b/lib/errors.go
@@ -47,7 +47,7 @@ func (e DecoratedError) Error() string {
 	}
 	loc := e.AST.NativeRep().SourceInfo().GetStartLocation(id)
 	errs := common.NewErrors(e.AST.Source())
-	errs.ReportErrorAtID(id, loc, e.Err.Error())
+	errs.ReportErrorAtID(id, loc, "%s", e.Err.Error())
 	return errs.ToDisplayString()
 }
 

--- a/testdata/http_error.txt
+++ b/testdata/http_error.txt
@@ -1,0 +1,11 @@
+! mito -data state.json src.cel
+! stdout .
+
+# Using pattern match rather than verbatim, since different environments
+# may return different error message text due to IP family differences.
+stderr ts=2006-01-02T15%3A04%3A05Z
+
+-- state.json --
+{"url": "", "id": 0}
+-- src.cel --
+get("https://localhost:9001/?"+{"ts": ["2006-01-02T15:04:05Z"]}.format_query())


### PR DESCRIPTION
The call to ReportErrorAtID was rendinging the error message as a format strings, resulting in confusion when the error message included % symbols as is common in URL. This happened because the symbols were being interpretted as fmt verbs, so ensure that the string is rendered verbatim by handing is to a %s verb.

Please take a look.