### PR TITLE
mito: add constant folding optimisation option

### DIFF
--- a/mito.go
+++ b/mito.go
@@ -73,6 +73,7 @@ func Main() int {
 	insecure := flag.Bool("insecure", false, "disable TLS verification in the HTTP client")
 	logTrace := flag.Bool("log_requests", false, "log request traces to stderr (go1.21+)")
 	maxTraceBody := flag.Int("max_log_body", 1000, "maximum length of body logged in request traces (go1.21+)")
+	fold := flag.Bool("fold", false, "apply constant folding optimisation")
 	version := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
 	if *version {
@@ -194,7 +195,7 @@ func Main() int {
 	}
 
 	for n := int(0); *maxExecutions < 0 || n < *maxExecutions; n++ {
-		res, val, err := eval(string(b), root, input, libs...)
+		res, val, err := eval(string(b), root, input, *fold, libs...)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return 1
@@ -324,15 +325,15 @@ func debug(tag string, value any) {
 	fmt.Fprintf(os.Stderr, "%s: logging %q: %v\n", level, tag, value)
 }
 
-func eval(src, root string, input interface{}, libs ...cel.EnvOption) (string, any, error) {
-	prg, ast, err := compile(src, root, libs...)
+func eval(src, root string, input interface{}, fold bool, libs ...cel.EnvOption) (string, any, error) {
+	prg, ast, err := compile(src, root, fold, libs...)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed program instantiation: %v", err)
 	}
 	return run(prg, ast, false, input)
 }
 
-func compile(src, root string, libs ...cel.EnvOption) (cel.Program, *cel.Ast, error) {
+func compile(src, root string, fold bool, libs ...cel.EnvOption) (cel.Program, *cel.Ast, error) {
 	opts := append([]cel.EnvOption{
 		cel.Declarations(decls.NewVar(root, decls.Dyn)),
 	}, libs...)
@@ -344,6 +345,17 @@ func compile(src, root string, libs ...cel.EnvOption) (cel.Program, *cel.Ast, er
 	ast, iss := env.Compile(src)
 	if iss.Err() != nil {
 		return nil, nil, fmt.Errorf("failed compilation: %v", iss.Err())
+	}
+
+	if fold {
+		folder, err := cel.NewConstantFoldingOptimizer()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed folding optimization: %v", err)
+		}
+		ast, iss = cel.NewStaticOptimizer(folder).Optimize(env, ast)
+		if iss.Err() != nil {
+			return nil, nil, fmt.Errorf("failed optimization: %v", iss.Err())
+		}
 	}
 
 	prg, err := env.Program(ast)

--- a/mito_bench_test.go
+++ b/mito_bench_test.go
@@ -36,45 +36,49 @@ var (
 
 var benchmarks = []struct {
 	name  string
-	setup func(*testing.B) (prg cel.Program, ast *cel.Ast, state any, err error)
+	setup func(*testing.B, bool) (prg cel.Program, ast *cel.Ast, state any, err error)
 }{
 	// Self-contained.
 	{
 		name: "hello_world_static",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			prg, ast, err := compile(
 				`"hello world"`,
 				root,
+				fold,
 			)
 			return prg, ast, nil, err
 		},
 	},
 	{
 		name: "hello_world_object_static",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			prg, ast, err := compile(
 				`{"greeting":"hello world"}`,
 				root,
+				fold,
 			)
 			return prg, ast, nil, err
 		},
 	},
 	{
 		name: "nested_static",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			prg, ast, err := compile(
 				`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`,
 				root,
+				fold,
 			)
 			return prg, ast, nil, err
 		},
 	},
 	{
 		name: "encode_json_static",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			prg, ast, err := compile(
 				`{"a":{"b":{"c":{"d":{"e":"f"}}}}}.encode_json()`,
 				root,
+				fold,
 				lib.JSON(nil),
 			)
 			return prg, ast, nil, err
@@ -82,10 +86,11 @@ var benchmarks = []struct {
 	},
 	{
 		name: "nested_collate_static",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			prg, ast, err := compile(
 				`{"a":{"b":{"c":{"d":{"e":"f"}}}}}.collate("a.b.c.d.e")`,
 				root,
+				fold,
 				lib.Collections(),
 			)
 			return prg, ast, nil, err
@@ -95,18 +100,19 @@ var benchmarks = []struct {
 	// From state.
 	{
 		name: "hello_world_state",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
-			prg, ast, err := compile(root, root)
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
+			prg, ast, err := compile(root, root, fold)
 			state := map[string]any{root: "hello world"}
 			return prg, ast, state, err
 		},
 	},
 	{
 		name: "hello_world_object_state",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			prg, ast, err := compile(
 				`{"greeting":state.greeting}`,
 				root,
+				fold,
 			)
 			state := map[string]any{root: mustParseJSON(`{"greeting": "hello world}"}`)}
 			return prg, ast, state, err
@@ -114,17 +120,18 @@ var benchmarks = []struct {
 	},
 	{
 		name: "nested_state",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
-			prg, ast, err := compile(root, root)
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
+			prg, ast, err := compile(root, root, fold)
 			state := map[string]any{root: mustParseJSON(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`)}
 			return prg, ast, state, err
 		},
 	},
 	{
 		name: "encode_json_state",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			prg, ast, err := compile(`state.encode_json()`,
 				root,
+				fold,
 				lib.JSON(nil),
 			)
 			state := map[string]any{root: mustParseJSON(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`)}
@@ -140,9 +147,10 @@ var benchmarks = []struct {
 	// Similar in the net versions below.
 	{
 		name: "nested_collate_list_state",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			prg, ast, err := compile(`[state].collate("a.b.c.d.e")`,
 				root,
+				fold,
 				lib.Collections(),
 			)
 			state := map[string]any{root: mustParseJSON(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`)}
@@ -151,9 +159,10 @@ var benchmarks = []struct {
 	},
 	{
 		name: "nested_collate_map_state",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			prg, ast, err := compile(`{"state": state}.collate("state.a.b.c.d.e")`,
 				root,
+				fold,
 				lib.Collections(),
 			)
 			state := map[string]any{root: mustParseJSON(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`)}
@@ -167,7 +176,7 @@ var benchmarks = []struct {
 		// This is to get an idea of how much of the bench work is coming from
 		// the test server.
 		name: "null_net",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
@@ -175,6 +184,7 @@ var benchmarks = []struct {
 			prg, ast, err := compile(
 				fmt.Sprintf(`get(%q).size()`, srv.URL),
 				root,
+				fold,
 				lib.HTTP(srv.Client(), nil, nil),
 			)
 			return prg, ast, nil, err
@@ -182,7 +192,7 @@ var benchmarks = []struct {
 	},
 	{
 		name: "hello_world_net",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.Write([]byte("hello world"))
 			}))
@@ -190,6 +200,7 @@ var benchmarks = []struct {
 			prg, ast, err := compile(
 				fmt.Sprintf(`string(get(%q).Body)`, srv.URL),
 				root,
+				fold,
 				lib.HTTP(srv.Client(), nil, nil),
 			)
 			return prg, ast, nil, err
@@ -197,7 +208,7 @@ var benchmarks = []struct {
 	},
 	{
 		name: "hello_world_object_net",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.Write([]byte(`{"greeting":"hello world"}`))
 			}))
@@ -205,6 +216,7 @@ var benchmarks = []struct {
 			prg, ast, err := compile(
 				fmt.Sprintf(`{"greeting":bytes(get(%q).Body).decode_json().greeting}`, srv.URL),
 				root,
+				fold,
 				lib.HTTP(srv.Client(), nil, nil),
 				lib.JSON(nil),
 			)
@@ -213,7 +225,7 @@ var benchmarks = []struct {
 	},
 	{
 		name: "nested_net",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.Write([]byte(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`))
 			}))
@@ -221,6 +233,7 @@ var benchmarks = []struct {
 			prg, ast, err := compile(
 				fmt.Sprintf(`bytes(get(%q).Body).decode_json()`, srv.URL),
 				root,
+				fold,
 				lib.HTTP(srv.Client(), nil, nil),
 				lib.JSON(nil),
 			)
@@ -229,7 +242,7 @@ var benchmarks = []struct {
 	},
 	{
 		name: "encode_json_null_net",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.Write([]byte(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`))
 			}))
@@ -237,6 +250,7 @@ var benchmarks = []struct {
 			prg, ast, err := compile(
 				fmt.Sprintf(`get(%q).Body`, srv.URL),
 				root,
+				fold,
 				lib.HTTP(srv.Client(), nil, nil),
 				lib.JSON(nil),
 			)
@@ -247,7 +261,7 @@ var benchmarks = []struct {
 		// encode_json_net should bead assessed with reference to encode_json_null_net
 		// which performs the same request but does not round-trip the object.
 		name: "encode_json_net",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.Write([]byte(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`))
 			}))
@@ -255,6 +269,7 @@ var benchmarks = []struct {
 			prg, ast, err := compile(
 				fmt.Sprintf(`bytes(get(%q).Body).decode_json().encode_json()`, srv.URL),
 				root,
+				fold,
 				lib.HTTP(srv.Client(), nil, nil),
 				lib.JSON(nil),
 			)
@@ -263,7 +278,7 @@ var benchmarks = []struct {
 	},
 	{
 		name: "nested_collate_list_net",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.Write([]byte(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`))
 			}))
@@ -271,6 +286,7 @@ var benchmarks = []struct {
 			prg, ast, err := compile(
 				fmt.Sprintf(`[bytes(get(%q).Body).decode_json()].collate("a.b.c.d.e")`, srv.URL),
 				root,
+				fold,
 				lib.HTTP(srv.Client(), nil, nil),
 				lib.JSON(nil),
 				lib.Collections(),
@@ -280,7 +296,7 @@ var benchmarks = []struct {
 	},
 	{
 		name: "nested_collate_map_net",
-		setup: func(b *testing.B) (cel.Program, *cel.Ast, any, error) {
+		setup: func(b *testing.B, fold bool) (cel.Program, *cel.Ast, any, error) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.Write([]byte(`{"a":{"b":{"c":{"d":{"e":"f"}}}}}`))
 			}))
@@ -288,6 +304,7 @@ var benchmarks = []struct {
 			prg, ast, err := compile(
 				fmt.Sprintf(`{"body": bytes(get(%q).Body).decode_json()}.collate("body.a.b.c.d.e")`, srv.URL),
 				root,
+				fold,
 				lib.HTTP(srv.Client(), nil, nil),
 				lib.JSON(nil),
 				lib.Collections(),
@@ -299,24 +316,32 @@ var benchmarks = []struct {
 
 func BenchmarkMito(b *testing.B) {
 	for _, bench := range benchmarks {
-		sampled := false
 		b.Run(bench.name, func(b *testing.B) {
-			b.StopTimer()
-			prg, ast, state, err := bench.setup(b)
-			if err != nil {
-				b.Fatalf("failed setup: %v", err)
-			}
-			b.StartTimer()
+			for _, fold := range []bool{false, true} {
+				name := "unfolded"
+				if fold {
+					name = "folded"
+				}
+				b.Run(name, func(b *testing.B) {
+					sampled := false
+					b.StopTimer()
+					prg, ast, state, err := bench.setup(b, fold)
+					if err != nil {
+						b.Fatalf("failed setup: %v", err)
+					}
+					b.StartTimer()
 
-			for i := 0; i < b.N; i++ {
-				v, _, err := run(prg, ast, *fastMarshal, state)
-				if err != nil {
-					b.Fatalf("failed operation: %v", err)
-				}
-				if *sampleBench && !sampled {
-					sampled = true
-					b.Logf("\n%s", v)
-				}
+					for i := 0; i < b.N; i++ {
+						v, _, err := run(prg, ast, *fastMarshal, state)
+						if err != nil {
+							b.Fatalf("failed operation: %v", err)
+						}
+						if *sampleBench && !sampled {
+							sampled = true
+							b.Logf("\n%s", v)
+						}
+					}
+				})
 			}
 		})
 	}

--- a/mito_test.go
+++ b/mito_test.go
@@ -133,27 +133,35 @@ func expand(ts *testscript.TestScript, neg bool, args []string) {
 }
 
 func TestSend(t *testing.T) {
-	chans := map[string]chan interface{}{"ch": make(chan interface{})}
-	send := lib.Send(chans)
+	for _, fold := range []bool{false, true} {
+		name := "unfolded"
+		if fold {
+			name = "folded"
+		}
+		t.Run(name, func(t *testing.T) {
+			chans := map[string]chan interface{}{"ch": make(chan interface{})}
+			send := lib.Send(chans)
 
-	var got interface{}
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		got = <-chans["ch"]
-	}()
+			var got interface{}
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				got = <-chans["ch"]
+			}()
 
-	res, _, err := eval(`42.send_to("ch").close("ch")`, "", nil, send)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if res != "true" {
-		t.Errorf("unexpected false result")
-	}
-	wg.Wait()
-	if got != int64(42) {
-		t.Errorf("unexpected sent result: got:%v want:42", got)
+			res, _, err := eval(`42.send_to("ch").close("ch")`, "", nil, fold, send)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if res != "true" {
+				t.Errorf("unexpected false result")
+			}
+			wg.Wait()
+			if got != int64(42) {
+				t.Errorf("unexpected sent result: got:%v want:42", got)
+			}
+		})
 	}
 }
 
@@ -243,12 +251,20 @@ func TestVars(t *testing.T) {
 }`
 	)
 
-	got, _, err := eval(src, "", interpreter.EmptyActivation(), vars)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if got != want {
-		t.Errorf("unexpected result: got:- want:+\n%v", cmp.Diff(got, want))
+	for _, fold := range []bool{false, true} {
+		name := "unfolded"
+		if fold {
+			name = "folded"
+		}
+		t.Run(name, func(t *testing.T) {
+			got, _, err := eval(src, "", interpreter.EmptyActivation(), fold, vars)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != want {
+				t.Errorf("unexpected result: got:- want:+\n%v", cmp.Diff(got, want))
+			}
+		})
 	}
 }
 
@@ -359,12 +375,20 @@ var regexpTests = []struct {
 func TestRegaxp(t *testing.T) {
 	for _, test := range regexpTests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := eval(test.src, "", interpreter.EmptyActivation(), lib.Regexp(test.regexps))
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if got != test.want {
-				t.Errorf("unexpected result: got:- want:+\n%v", cmp.Diff(got, test.want))
+			for _, fold := range []bool{false, true} {
+				name := "unfolded"
+				if fold {
+					name = "folded"
+				}
+				t.Run(name, func(t *testing.T) {
+					got, _, err := eval(test.src, "", interpreter.EmptyActivation(), fold, lib.Regexp(test.regexps))
+					if err != nil {
+						t.Errorf("unexpected error: %v", err)
+					}
+					if got != test.want {
+						t.Errorf("unexpected result: got:- want:+\n%v", cmp.Diff(got, test.want))
+					}
+				})
 			}
 		})
 	}


### PR DESCRIPTION
This is an experiment to show that constant folding gives worthwhile improvements in benchmarks.

ref:https://pkg.go.dev/github.com/google/cel-go/cel#NewConstantFoldingOptimizer

Constant folding is one of three optimisations that are available. The other two (sets and variable inlining) are either less relevant to our use or not zero-configuration, so they have been left.

```
                                           │  out.bench   │
                                           │    sec/op    │
Mito/hello_world_static/unfolded-20          584.7n ±  5%
Mito/hello_world_static/folded-20            607.1n ±  8%
Mito/hello_world_object_static/unfolded-20   3.887µ ±  8%
Mito/hello_world_object_static/folded-20     3.762µ ±  4%
Mito/nested_static/unfolded-20               15.09µ ± 15%
Mito/nested_static/folded-20                 14.40µ ±  5%
Mito/encode_json_static/unfolded-20          15.04µ ±  2%
Mito/encode_json_static/folded-20            1.089µ ±  8%
Mito/nested_collate_static/unfolded-20       6.519µ ±  5%
Mito/nested_collate_static/folded-20         1.642µ ±  4%
Mito/hello_world_state/unfolded-20           703.7n ±  5%
Mito/hello_world_state/folded-20             704.5n ±  8%
Mito/hello_world_object_state/unfolded-20    4.035µ ±  3%
Mito/hello_world_object_state/folded-20      4.042µ ±  6%
Mito/nested_state/unfolded-20                12.38µ ±  5%
Mito/nested_state/folded-20                  12.44µ ±  3%
Mito/encode_json_state/unfolded-20           3.398µ ±  5%
Mito/encode_json_state/folded-20             3.365µ ±  8%
Mito/nested_collate_list_state/unfolded-20   14.79µ ±  7%
Mito/nested_collate_list_state/folded-20     14.47µ ±  7%
Mito/nested_collate_map_state/unfolded-20    15.32µ ±  4%
Mito/nested_collate_map_state/folded-20      15.45µ ±  9%
Mito/null_net/unfolded-20                    78.01µ ± 12%
Mito/null_net/folded-20                      520.7n ± 12%
Mito/hello_world_net/unfolded-20             102.6µ ±  8%
Mito/hello_world_net/folded-20               655.7n ±  7%
Mito/hello_world_object_net/unfolded-20      121.2µ ±  9%
Mito/hello_world_object_net/folded-20        4.298µ ±  2%
Mito/nested_net/unfolded-20                  162.8µ ± 13%
Mito/nested_net/folded-20                    17.11µ ±  4%
Mito/encode_json_null_net/unfolded-20        108.9µ ±  6%
Mito/encode_json_null_net/folded-20          1.400µ ±  6%
Mito/encode_json_net/unfolded-20             126.7µ ±  8%
Mito/encode_json_net/folded-20               1.211µ ±  6%
Mito/nested_collate_list_net/unfolded-20     157.1µ ± 46%
Mito/nested_collate_list_net/folded-20       1.655µ ± 32%
Mito/nested_collate_map_net/unfolded-20      167.9µ ±  7%
Mito/nested_collate_map_net/folded-20        1.778µ ±  5%
```

Please take a look.