### PR TITLE
lib: relax type hints on flatten function

### DIFF
--- a/lib/collections.go
+++ b/lib/collections.go
@@ -358,8 +358,8 @@ func (collectionsLib) CompileOptions() []cel.EnvOption {
 		cel.Function("flatten",
 			cel.MemberOverload(
 				"list_flatten",
-				[]*cel.Type{listV},
-				listV,
+				[]*cel.Type{listDyn},
+				listDyn,
 				cel.UnaryBinding(catch(flatten)),
 			),
 		),

--- a/testdata/flatten_types.txt
+++ b/testdata/flatten_types.txt
@@ -1,0 +1,87 @@
+mito -use collections -data state.json src.cel
+! stderr .
+cmp stdout want.txt
+
+-- state.json --
+{
+	"aye": {
+		"value": 1
+	},
+	"bee": {
+		"value": "two"
+	},
+	"one": [
+		{
+			"value": 1
+		},
+		{
+			"value": "two"
+		}
+	],
+	"two": [
+		{
+			"value": 3
+		},
+		{
+			"value": "four"
+		}
+	]
+}
+
+-- src.cel --
+[
+	"one",
+	"two",
+].map(k, state[k].map(e, {
+	k: e,
+})).flatten().map(d, d.with({
+	"aye": state.aye,
+	"bee": state.bee,
+}))
+-- want.txt --
+[
+	{
+		"aye": {
+			"value": 1
+		},
+		"bee": {
+			"value": "two"
+		},
+		"one": {
+			"value": 1
+		}
+	},
+	{
+		"aye": {
+			"value": 1
+		},
+		"bee": {
+			"value": "two"
+		},
+		"one": {
+			"value": "two"
+		}
+	},
+	{
+		"aye": {
+			"value": 1
+		},
+		"bee": {
+			"value": "two"
+		},
+		"two": {
+			"value": 3
+		}
+	},
+	{
+		"aye": {
+			"value": 1
+		},
+		"bee": {
+			"value": "two"
+		},
+		"two": {
+			"value": "four"
+		}
+	}
+]


### PR DESCRIPTION
The documented type signature of the flatten function is `<list<dyn>> -> <list<dyn>>`, but the implementation was `<list<typeV>> -> <list<typeV>>`. This has an impact on uses of flatten where the input is a nested set of lists, the exact intended use-case. In this situation, the type checker is told that the returned value is a list of lists..., resulting in rejection of valid programs. There is a work-around that can be used, but instead, just make the implementation match the documentation and intention.

Please take a look.