### PR TITLE
lib: fix formatting of As macro heading

### DIFF
--- a/lib/collections.go
+++ b/lib/collections.go
@@ -34,7 +34,7 @@ import (
 // Collections returns a cel.EnvOption to configure extended functions for
 // handling collections.
 //
-// As (Macro)
+// # As (Macro)
 //
 // The as macro is syntactic sugar for [val].map(var, function)[0].
 //


### PR DESCRIPTION
The "As" heading is not picked up because it is not correctly marked, this means there is no link and it is not raised to the appropriate H.

Please take a look.