### PR TITLE
feat(ci): run govulncheck

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,3 +28,8 @@ jobs:
 
     - name: Test Race
       run: go test -race ./...
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: golang/govulncheck-action@v1


### PR DESCRIPTION
Run `govulncheck` to check for known vulnerabilities in the latest Go version.  This is placed in a dedicated job to allow testing to continue even if vulnerability checks fail (which may occur when no patch is available).

References:

- https://github.com/golang/govulncheck-action
- https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck

Closes #58