### PR TITLE
Azure OAuth: use the configured token URL

### DIFF
--- a/mito.go
+++ b/mito.go
@@ -535,9 +535,9 @@ func oAuth2Client(cfg OAuth2) (*http.Client, error) {
 
 		fallthrough
 	case "azure":
-		var token string
+		token := cfg.TokenURL
 		if prov == "azure" {
-			if cfg.TokenURL == "" {
+			if token == "" {
 				token = endpoints.AzureAD(cfg.AzureTenantID).TokenURL
 			}
 			if cfg.AzureResource != "" {


### PR DESCRIPTION
Fixes a bug where setting `auth.oauth2.token_url` with the Azure provider resulted in an empty token URL being used.