### PR TITLE
Use basic/token auth when doing explicitly constructed requests

### DIFF
--- a/lib/http.go
+++ b/lib/http.go
@@ -43,8 +43,8 @@ import (
 // the http.DefaultClient will be used and if limit is nil an non-limiting
 // rate.Limiter will be used. If auth is not nil, the Authorization header
 // is populated for basic authentication or token authentication. Explicitly
-// constructed requests can also add basic authentication in CEL, using the
-// basic_authentication method.
+// constructed requests can alternatively add basic authentication in CEL,
+// using the basic_authentication method.
 //
 // # HEAD
 //

--- a/lib/http.go
+++ b/lib/http.go
@@ -42,11 +42,9 @@ import (
 // will be used for the requests and API rate limiting. If client is nil
 // the http.DefaultClient will be used and if limit is nil an non-limiting
 // rate.Limiter will be used. If auth is not nil, the Authorization header
-// is populated for Basic Authentication or token authentication in requests
-// constructed for direct HEAD, GET and POST method calls. Explicitly constructed
-// requests used in do_request are not affected by auth. In cases where Basic
-// Authentication is needed for these constructed requests, the
-// basic_authentication method can be used to add the necessary header.
+// is populated for basic authentication or token authentication. Explicitly
+// constructed requests can also add basic authentication in CEL, using the
+// basic_authentication method.
 //
 // # HEAD
 //
@@ -845,6 +843,12 @@ func (l httpLib) doRequest(arg ref.Val) ref.Val {
 	err = l.options.Limiter.Wait(l.ctx)
 	if err != nil {
 		return types.NewErr("%s", err)
+	}
+	if l.options.BasicAuth != nil {
+		req.SetBasicAuth(l.options.BasicAuth.Username, l.options.BasicAuth.Password)
+	}
+	if l.options.TokenAuth != nil {
+		l.options.TokenAuth.AddTo(req.Header)
 	}
 	addHeaders(req, l.options.Headers)
 	resp, err := l.client.Do(req)


### PR DESCRIPTION
Use the basic/token auth configuration not just for direct requests
(e.g. `get('http://www.example.com/')`, but also when doing explicitly
constructed requests (e.g. `get_request(...).do_request()` or
`request("GET", ...).do_request()`).

This matches the behavior of the `auth.oauth2` configuration, which applies to all requests.

It means that the choice of whether to apply basic/token auth automatically by configuration or explicitly in CEL is separate from the choice of how to construct requests in general.

Related:
* https://github.com/elastic/mito/pull/19
* https://github.com/elastic/mito/pull/23
* lib: add open-ended HTTP lib configuration constructor https://github.com/elastic/mito/commit/c926ec829ecae8ef475f5bb4a6f1abb384b0abdb
* https://github.com/elastic/mito/pull/97

Related in beats:
* https://github.com/elastic/beats/pull/36932
* https://github.com/elastic/beats/pull/45359