### PR TITLE
fix: resolve encode_json error for ref.Val lists

### DIFF
--- a/lib/json.go
+++ b/lib/json.go
@@ -251,7 +251,7 @@ func encodeJSON(val ref.Val) ref.Val {
 	switch under := val.Value().(type) {
 	case map[string]any:
 		v = under
-	case map[ref.Val]ref.Val:
+	case map[ref.Val]ref.Val, []ref.Val:
 		pb, err := val.ConvertToNative(structpbValueType)
 		if err != nil {
 			return types.NewErr("failed proto conversion: %v", err)

--- a/testdata/json_encode.txt
+++ b/testdata/json_encode.txt
@@ -23,6 +23,7 @@ cmp stdout want.txt
 	}),
 	"plain text".encode_json(),
 	encode_json("plain text"),
+	[0, 1].map(i, {"a":i}).encode_json()
 ]
 -- want.txt --
 [
@@ -32,5 +33,6 @@ cmp stdout want.txt
 	"{\"a\":{\"b\":{\"c\":1}}}",
 	"{\"a\":{\"b\":{\"c\":1}}}",
 	"\"plain text\"",
-	"\"plain text\""
+	"\"plain text\"",
+	"[{\"a\":0},{\"a\":1}]"
 ]


### PR DESCRIPTION
Fixes JSON marshaling failure when encoding lists containing
map[ref.Val]ref.Val types. The error "json: unsupported type:
map[ref.Val]ref.Val" occurred when calling encode_json() on
expressions like [0, 1].map(i, {"a":i}).encode_json().

The fix extends the protobuf conversion case to handle both
map[ref.Val]ref.Val (existing) and []ref.Val (new) types.