### PR TITLE
lib: remove incorrect period scaling

### DIFF
--- a/lib/limit.go
+++ b/lib/limit.go
@@ -489,7 +489,6 @@ func limitPolicy(h http.Header, prefix string, canonical, delta bool, window tim
 		m["error"] = fmt.Sprintf("could not parse %q as number or timestamp", reset)
 		return m
 	}
-	per *= window.Seconds()
 
 	m["next"] = rate.Limit(lim / window.Seconds())
 	m["rate"] = rate.Limit(rem / per)

--- a/testdata/get.txt
+++ b/testdata/get.txt
@@ -3,31 +3,23 @@ mito -use http,collections src.cel
 cmp stdout want.txt
 
 -- src.cel --
-get("http://www.example.com/").drop([
-	"Header.Accept-Ranges",
-	"Header.Age",
-	"Header.Date",
-	"Header.Etag",
-	"Header.Cache-Control",
-	"Header.Last-Modified",
-	"Header.X-Cache",
-	"Header.Expires",
-	"Header.Server",
+get("http://www.example.com/").as(resp, 
+	resp.with({
+		"Body": resp.Body == b"" ? resp.Body : b"some text",
+		"Header": {?"Content-Type": resp.?Header["Content-Type"]},
+	})
+).drop([
+	"ContentLength",
+	"TransferEncoding",
+	"Uncompressed",
 ])
 -- want.txt --
 {
-	"Body": "PCFkb2N0eXBlIGh0bWw+PGh0bWwgbGFuZz0iZW4iPjxoZWFkPjx0aXRsZT5FeGFtcGxlIERvbWFpbjwvdGl0bGU+PG1ldGEgbmFtZT0idmlld3BvcnQiIGNvbnRlbnQ9IndpZHRoPWRldmljZS13aWR0aCwgaW5pdGlhbC1zY2FsZT0xIj48c3R5bGU+Ym9keXtiYWNrZ3JvdW5kOiNlZWU7d2lkdGg6NjB2dzttYXJnaW46MTV2aCBhdXRvO2ZvbnQtZmFtaWx5OnN5c3RlbS11aSxzYW5zLXNlcmlmfWgxe2ZvbnQtc2l6ZToxLjVlbX1kaXZ7b3BhY2l0eTowLjh9YTpsaW5rLGE6dmlzaXRlZHtjb2xvcjojMzQ4fTwvc3R5bGU+PGJvZHk+PGRpdj48aDE+RXhhbXBsZSBEb21haW48L2gxPjxwPlRoaXMgZG9tYWluIGlzIGZvciB1c2UgaW4gZG9jdW1lbnRhdGlvbiBleGFtcGxlcyB3aXRob3V0IG5lZWRpbmcgcGVybWlzc2lvbi4gQXZvaWQgdXNlIGluIG9wZXJhdGlvbnMuPHA+PGEgaHJlZj0iaHR0cHM6Ly9pYW5hLm9yZy9kb21haW5zL2V4YW1wbGUiPkxlYXJuIG1vcmU8L2E+PC9kaXY+PC9ib2R5PjwvaHRtbD4K",
+	"Body": "c29tZSB0ZXh0",
 	"Close": false,
-	"ContentLength": -1,
 	"Header": {
-		"Connection": [
-			"keep-alive"
-		],
 		"Content-Type": [
 			"text/html"
-		],
-		"Vary": [
-			"Accept-Encoding"
 		]
 	},
 	"Proto": "HTTP/1.1",
@@ -45,6 +37,5 @@ get("http://www.example.com/").drop([
 		"URL": "http://www.example.com/"
 	},
 	"Status": "200 OK",
-	"StatusCode": 200,
-	"Uncompressed": true
+	"StatusCode": 200
 }

--- a/testdata/get_log_req.txt
+++ b/testdata/get_log_req.txt
@@ -3,31 +3,23 @@ stderr 'transaction\.id'
 cmp stdout want.txt
 
 -- src.cel --
-get("http://www.example.com/").drop([
-	"Header.Accept-Ranges",
-	"Header.Age",
-	"Header.Date",
-	"Header.Etag",
-	"Header.Cache-Control",
-	"Header.Last-Modified",
-	"Header.X-Cache",
-	"Header.Expires",
-	"Header.Server",
+get("http://www.example.com/").as(resp, 
+	resp.with({
+		"Body": resp.Body == b"" ? resp.Body : b"some text",
+		"Header": {?"Content-Type": resp.?Header["Content-Type"]},
+	})
+).drop([
+	"ContentLength",
+	"TransferEncoding",
+	"Uncompressed",
 ])
 -- want.txt --
 {
-	"Body": "PCFkb2N0eXBlIGh0bWw+PGh0bWwgbGFuZz0iZW4iPjxoZWFkPjx0aXRsZT5FeGFtcGxlIERvbWFpbjwvdGl0bGU+PG1ldGEgbmFtZT0idmlld3BvcnQiIGNvbnRlbnQ9IndpZHRoPWRldmljZS13aWR0aCwgaW5pdGlhbC1zY2FsZT0xIj48c3R5bGU+Ym9keXtiYWNrZ3JvdW5kOiNlZWU7d2lkdGg6NjB2dzttYXJnaW46MTV2aCBhdXRvO2ZvbnQtZmFtaWx5OnN5c3RlbS11aSxzYW5zLXNlcmlmfWgxe2ZvbnQtc2l6ZToxLjVlbX1kaXZ7b3BhY2l0eTowLjh9YTpsaW5rLGE6dmlzaXRlZHtjb2xvcjojMzQ4fTwvc3R5bGU+PGJvZHk+PGRpdj48aDE+RXhhbXBsZSBEb21haW48L2gxPjxwPlRoaXMgZG9tYWluIGlzIGZvciB1c2UgaW4gZG9jdW1lbnRhdGlvbiBleGFtcGxlcyB3aXRob3V0IG5lZWRpbmcgcGVybWlzc2lvbi4gQXZvaWQgdXNlIGluIG9wZXJhdGlvbnMuPHA+PGEgaHJlZj0iaHR0cHM6Ly9pYW5hLm9yZy9kb21haW5zL2V4YW1wbGUiPkxlYXJuIG1vcmU8L2E+PC9kaXY+PC9ib2R5PjwvaHRtbD4K",
+	"Body": "c29tZSB0ZXh0",
 	"Close": false,
-	"ContentLength": -1,
 	"Header": {
-		"Connection": [
-			"keep-alive"
-		],
 		"Content-Type": [
 			"text/html"
-		],
-		"Vary": [
-			"Accept-Encoding"
 		]
 	},
 	"Proto": "HTTP/1.1",
@@ -45,6 +37,5 @@ get("http://www.example.com/").drop([
 		"URL": "http://www.example.com/"
 	},
 	"Status": "200 OK",
-	"StatusCode": 200,
-	"Uncompressed": true
+	"StatusCode": 200
 }

--- a/testdata/head.txt
+++ b/testdata/head.txt
@@ -3,29 +3,21 @@ mito -use http,collections src.cel
 cmp stdout want.txt
 
 -- src.cel --
-head("http://www.example.com/").drop([
+head("http://www.example.com/").as(resp, 
+	resp.with({
+		"Body": resp.Body == b"" ? resp.Body : b"some text",
+		"Header": {?"Content-Type": resp.?Header["Content-Type"]},
+	})
+).drop([
 	"ContentLength",
-	"Header.Accept-Ranges",
-	"Header.Age",
-	"Header.Content-Encoding",
-	"Header.Content-Length",
-	"Header.Date",
-	"Header.Etag",
-	"Header.Cache-Control",
-	"Header.Last-Modified",
-	"Header.Vary",
-	"Header.X-Cache",
-	"Header.Expires",
-	"Header.Server",
+	"TransferEncoding",
+	"Uncompressed",
 ])
 -- want.txt --
 {
 	"Body": "",
 	"Close": false,
 	"Header": {
-		"Connection": [
-			"keep-alive"
-		],
 		"Content-Type": [
 			"text/html"
 		]
@@ -45,6 +37,5 @@ head("http://www.example.com/").drop([
 		"URL": "http://www.example.com/"
 	},
 	"Status": "200 OK",
-	"StatusCode": 200,
-	"Uncompressed": false
+	"StatusCode": 200
 }

--- a/testdata/limit_general.txt
+++ b/testdata/limit_general.txt
@@ -45,6 +45,11 @@ cmp stdout want.txt
 		"X-RateLimit-Remaining": ["100"],
 		"X-RateLimit-Reset": [string(int(timestamp("9999-12-31T23:59:59.999999999Z")))]
 	}.as(h, rate_limit(h, 'X-RateLimit', false, false, duration('1s'), 100)),
+	{
+		"X-RateLimit-Limit": ["5000"],
+		"X-RateLimit-Remaining": ["100"],
+		"X-RateLimit-Reset": [string(int(timestamp("9999-12-31T23:59:59.999999999Z")))]
+	}.as(h, rate_limit(h, 'X-RateLimit', false, false, duration('1m'), 100)),
 ]
 -- want.txt --
 [
@@ -101,6 +106,13 @@ cmp stdout want.txt
 		"burst": 100,
 		"headers": "X-RateLimit-Limit=\"5000\" X-RateLimit-Remaining=\"100\" X-RateLimit-Reset=\"253402300799\"",
 		"next": 5000,
+		"rate": 1.0842021724855044e-8,
+		"reset": "9999-12-31T23:59:59Z"
+	},
+	{
+		"burst": 100,
+		"headers": "X-RateLimit-Limit=\"5000\" X-RateLimit-Remaining=\"100\" X-RateLimit-Reset=\"253402300799\"",
+		"next": 83.33333333333333,
 		"rate": 1.0842021724855044e-8,
 		"reset": "9999-12-31T23:59:59Z"
 	}


### PR DESCRIPTION
A dimensional analysis would have shown this to be incorrect; per is the period over which the rate value is applied and so should be in s, but this makes it in s², giving a rate in s¯².

Please take a look.

Fixes #117.