### PR TITLE
lib,mod: handle map[any]any and []any from cel-go v0.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 )
 
 retract (
+	v1.25.0 // Breaks map/list ConvertToNative due to cel-go v0.27.0 (google/cel-go#1261).
 	v1.20.1 // Self-retraction.
 	v1.20.0 // Used v1 of the AWS v4 signing SDK.
 )

--- a/lib/http.go
+++ b/lib/http.go
@@ -934,6 +934,13 @@ func makeMapStrings(val reflect.Value) (reflect.Value, error) {
 			return reflect.Value{}, err
 		}
 		return reflect.ValueOf(v), nil
+	case map[any]any:
+		val := types.DefaultTypeAdapter.NativeToValue(iface)
+		v, err := val.ConvertToNative(reflectMapStringStringSliceType)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		return reflect.ValueOf(v), nil
 	case ref.Val:
 		v, err := iface.ConvertToNative(reflectMapStringStringSliceType)
 		if err != nil {
@@ -972,6 +979,13 @@ func makeStrings(val reflect.Value) (reflect.Value, error) {
 			dst[i] = v.(string)
 		}
 		return reflect.ValueOf(dst), nil
+	case []any:
+		val := types.DefaultTypeAdapter.NativeToValue(iface)
+		v, err := val.ConvertToNative(reflectStringSliceType)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		return reflect.ValueOf(v), nil
 	default:
 		return reflect.Value{}, fmt.Errorf("invalid type: %T", iface)
 	}

--- a/lib/limit.go
+++ b/lib/limit.go
@@ -165,6 +165,13 @@ func mapStrings(val ref.Val) (map[string][]string, error) {
 			return nil, err
 		}
 		return v.(map[string][]string), nil
+	case map[any]any:
+		val := types.DefaultTypeAdapter.NativeToValue(iface)
+		v, err := val.ConvertToNative(reflectMapStringStringSliceType)
+		if err != nil {
+			return nil, err
+		}
+		return v.(map[string][]string), nil
 	case ref.Val:
 		v, err := iface.ConvertToNative(reflectMapStringStringSliceType)
 		if err != nil {


### PR DESCRIPTION
cel-go v0.27.0 (google/cel-go#1261) changed ConvertToNative to remap interface{} targets to map[any]any for maps and []any for lists. This breaks type switches in makeMapStrings, makeStrings, and mapStrings that expected the previous map[ref.Val]ref.Val and []ref.Val types.

Add cases for the new types, round-tripping through NativeToValue and ConvertToNative with an explicit target type.

Retract v1.25.0 which shipped without this fix.

This will be tagged as v1.25.1, tested against filebeat cel input tests.