### PR TITLE
ci,mod: update cel-go to v0.28.0 and use dynamic go version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,18 +10,18 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [stable, oldstable]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     - name: Test
       run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/mito
 
-go 1.25.0
+go 1.25.8
 
 require (
 	aqwari.net/xml v0.0.0-20210331023308-d9421b293817
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.17
 	github.com/goccy/go-yaml v1.9.5
 	github.com/golang/protobuf v1.5.2
-	github.com/google/cel-go v0.27.0
+	github.com/google/cel-go v0.28.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.3.0
 	github.com/rogpeppe/go-internal v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/goccy/go-yaml v1.9.5/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3K
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/google/cel-go v0.27.0 h1:e7ih85+4qVrBuqQWTW4FKSqZYokVuc3HnhH5keboFTo=
-github.com/google/cel-go v0.27.0/go.mod h1:tTJ11FWqnhw5KKpnWpvW9CJC3Y9GK4EIS0WXnBbebzw=
+github.com/google/cel-go v0.28.0 h1:KjSWstCpz/MN5t4a8gnGJNIYUsJRpdi/r97xWDphIQc=
+github.com/google/cel-go v0.28.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/testdata/error_text.txt
+++ b/testdata/error_text.txt
@@ -1,0 +1,16 @@
+! mito -data data.json src.cel
+cmp stderr want.txt
+
+-- data.json --
+{"url":"https://example.com/"}
+-- src.cel --
+get(state.url).Body.decode_json().records.map(r,
+//                             ^~~~ https://example.com/ is not serving JSON.
+	get(state.url+'/'+r.id).Body.decode_json()
+).as(events, {
+	"events": events,
+})
+-- want.txt --
+failed eval: ERROR: <input>:1:32: failed to unmarshal JSON message: invalid character '<' looking for beginning of value
+ | get(state.url).Body.decode_json().records.map(r,
+ | ...............................^

--- a/testdata/macro_error.txt
+++ b/testdata/macro_error.txt
@@ -7,6 +7,6 @@ cmp stderr want_err.txt
 -- src.cel --
 get(state.url+state.id).as(r, r.map(k, k))
 -- want_err.txt --
-failed eval: ERROR: <input>:1:31: no such overload
+failed eval: ERROR: <input>:1:14: no such overload
  | get(state.url+state.id).as(r, r.map(k, k))
- | ..............................^
+ | .............^

--- a/testdata/serve_tls.txt
+++ b/testdata/serve_tls.txt
@@ -4,7 +4,7 @@ cmpenv src.cel src_var.cel
 
 ! mito -use http src.cel
 ! stdout .
-stderr 'failed eval: ERROR: <input>:2:62: Get "https://127.0.0.1:[0-9]{1,5}": (?:tls: failed to verify certificate: )?x509: (?:certificate signed by unknown authority|.*certificate is not trusted)'
+stderr 'failed eval: ERROR: <input>:2:[0-9]{1,3}: Get "https://127.0.0.1:[0-9]{1,5}": (?:tls: failed to verify certificate: )?x509: (?:certificate signed by unknown authority|.*certificate is not trusted)'
 
 mito -use http -insecure src.cel
 cmp stdout want_insecure.txt


### PR DESCRIPTION
cel-go v0.28.0 fixes runtime node identity retention, so also update tests to capture the correct expected error locations.

Please take a look.